### PR TITLE
feat(worker): add async-operation scheduler process

### DIFF
--- a/apps/fsm-core-worker-ts/src/asyncOperationScheduler/asyncOperationScheduler.ts
+++ b/apps/fsm-core-worker-ts/src/asyncOperationScheduler/asyncOperationScheduler.ts
@@ -1,0 +1,94 @@
+import { getLogger } from "@logtape/logtape";
+import { Pool } from "pg";
+import { asyncOperationScheduleNextPending } from "@pgfsm/db";
+
+export { asyncOperationScheduleNextPending } from "@pgfsm/db";
+
+const logger = getLogger(["@pgfsm/scheduler", "async-operation"]);
+
+export const ASYNC_OPERATION_SCHEDULER_NOTIFY_CHANNEL =
+  "async_operation_scheduler_work";
+
+const DEFAULT_STALE_THRESHOLD_S = 30;
+const DEFAULT_FALLBACK_POLL_INTERVAL_MS = 30_000;
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export type AsyncOperationSchedulerOptions = {
+  signal?: AbortSignal;
+  staleThresholdSeconds?: number;
+  /** Fallback poll interval in ms — catches pg_notify missed after a LISTEN connection drop. Default: 30000. */
+  pollIntervalMs?: number;
+};
+
+/**
+ * Async-operation scheduler — control-plane routing process (kube-scheduler
+ * equivalent) for async-operation workerlets.
+ *
+ * Listens on the 'async_operation_scheduler_work' pg_notify channel. When a
+ * dispatch entry is enqueued, the notification fires a scheduling cycle which
+ * calls fsm_core.async_operation_schedule_next_pending() in a loop until the
+ * queue is empty or no workerlet has capacity. The PG function handles claim +
+ * filter/score + assign + notify in a single transaction.
+ *
+ * A fallback poll runs every 30 s to catch any missed notifications.
+ * Run this on the control plane alongside the API server.
+ */
+export async function runAsyncOperationScheduler(
+  dbConfig: { connectionString: string; max?: number },
+  options?: AsyncOperationSchedulerOptions,
+): Promise<void> {
+  const signal = options?.signal;
+  const staleSecs = options?.staleThresholdSeconds ?? DEFAULT_STALE_THRESHOLD_S;
+  const fallbackPollMs = options?.pollIntervalMs ??
+    DEFAULT_FALLBACK_POLL_INTERVAL_MS;
+
+  const pool = new Pool(dbConfig);
+  const deps = { db: pool, useSupabase: false };
+
+  // One scheduling cycle: drain all pending entries until the queue is empty
+  // or no workerlet has capacity. Each call to asyncOperationScheduleNextPending
+  // delegates entirely to fsm_core.async_operation_schedule_next_pending() — no
+  // TypeScript-side workerlet selection or separate registry query needed.
+  const runCycle = async () => {
+    try {
+      while (await asyncOperationScheduleNextPending(deps, staleSecs)) {
+        // keep going until queue is empty or no capable workerlet
+      }
+    } catch (err) {
+      logger.error("Async-operation scheduler cycle error: {error}", {
+        error: err,
+      });
+    }
+  };
+
+  // Dedicated LISTEN connection — held for the process lifetime, released on shutdown.
+  const listenClient = await pool.connect();
+  await listenClient.query(
+    `LISTEN "${ASYNC_OPERATION_SCHEDULER_NOTIFY_CHANNEL}"`,
+  );
+  listenClient.on("notification", (msg) => {
+    if (msg.channel === ASYNC_OPERATION_SCHEDULER_NOTIFY_CHANNEL) {
+      runCycle();
+    }
+  });
+
+  logger.info("Async-operation scheduler listening on channel: {channel}", {
+    channel: ASYNC_OPERATION_SCHEDULER_NOTIFY_CHANNEL,
+  });
+
+  // Run an initial cycle in case entries were enqueued before this process started.
+  await runCycle();
+
+  // Fallback poll loop — also serves as the main blocking mechanism.
+  while (!signal?.aborted) {
+    await sleep(fallbackPollMs);
+    if (signal?.aborted) break;
+    await runCycle();
+  }
+
+  listenClient.release();
+  await pool.end();
+  logger.info("Async-operation scheduler stopped");
+}

--- a/apps/fsm-core-worker-ts/src/cli/async-operation-scheduler.ts
+++ b/apps/fsm-core-worker-ts/src/cli/async-operation-scheduler.ts
@@ -1,0 +1,116 @@
+import { parseArgs } from "@std/cli/parse-args";
+import dotenv from "dotenv";
+import { getLogger } from "@logtape/logtape";
+import { configureWorkerLogger } from "../logger.ts";
+import { runAsyncOperationScheduler } from "../asyncOperationScheduler/asyncOperationScheduler.ts";
+import type { AsyncOperationSchedulerOptions } from "../asyncOperationScheduler/asyncOperationScheduler.ts";
+
+const logger = getLogger(["@pgfsm/scheduler", "async-operation", "cli"]);
+await configureWorkerLogger();
+
+const args = parseArgs(Deno.args, {
+  string: ["db-url", "poll-interval", "stale-threshold"],
+  boolean: ["help"],
+  alias: {
+    h: "help",
+    d: "db-url",
+    p: "poll-interval",
+    s: "stale-threshold",
+  },
+});
+
+function printHelp(): void {
+  logger.info(`
+async-operation-scheduler — async-operation dispatch scheduler (kube-scheduler equivalent)
+
+USAGE
+  deno run --allow-all src/cli/async-operation-scheduler.ts [options]
+
+OPTIONS
+  -d, --db-url <url>             Database connection URL (overrides DATABASE_URL from .env)
+  -p, --poll-interval <ms>       Fallback poll interval in milliseconds (default: 30000)
+  -s, --stale-threshold <secs>   Seconds before a workerlet is considered dead (default: 30)
+  -h, --help                     Show this help message
+
+DESCRIPTION
+  Listens on the 'async_operation_scheduler_work' pg_notify channel. When a
+  dispatch entry appears in async_operation_instance_and_async_operation_workerlet,
+  runs a scheduling cycle: SELECT FOR UPDATE SKIP LOCKED, filter+score active
+  async-operation workerlets, UPDATE to 'scheduled', pg_notify the winning
+  workerlet. A fallback poll runs every 30 s for missed notifications.
+  Run on the control plane alongside the API server — NOT on workerlet nodes.
+`);
+}
+
+if (args.help) {
+  printHelp();
+  Deno.exit(0);
+}
+
+dotenv.config({ path: ".env" });
+const resolvedDbUrl = args["db-url"] ?? Deno.env.get("DATABASE_URL") ?? "";
+
+if (!resolvedDbUrl) {
+  logger.error("DATABASE_URL is required (set in .env or pass --db-url)");
+  Deno.exit(1);
+}
+
+const pollIntervalArg = args["poll-interval"];
+const pollIntervalMs = pollIntervalArg ? Number(pollIntervalArg) : undefined;
+if (
+  pollIntervalMs !== undefined &&
+  (!Number.isInteger(pollIntervalMs) || pollIntervalMs < 1)
+) {
+  logger.error("--poll-interval must be a positive integer, got: {value}", {
+    value: pollIntervalArg,
+  });
+  Deno.exit(1);
+}
+
+const staleThresholdArg = args["stale-threshold"];
+const staleThresholdSeconds = staleThresholdArg
+  ? Number(staleThresholdArg)
+  : undefined;
+if (
+  staleThresholdSeconds !== undefined &&
+  (!Number.isInteger(staleThresholdSeconds) || staleThresholdSeconds < 1)
+) {
+  logger.error("--stale-threshold must be a positive integer, got: {value}", {
+    value: staleThresholdArg,
+  });
+  Deno.exit(1);
+}
+
+const options: AsyncOperationSchedulerOptions = {
+  pollIntervalMs,
+  staleThresholdSeconds,
+};
+
+const controller = new AbortController();
+let shutdownRequested = false;
+
+const onSignal = () => {
+  if (shutdownRequested) {
+    logger.info("Force exit.");
+    Deno.exit(0);
+  }
+  shutdownRequested = true;
+  logger.info(
+    "Shutdown requested — stopping async-operation scheduler gracefully. Ctrl+C again to force exit...",
+  );
+  controller.abort();
+};
+
+Deno.addSignalListener("SIGINT", onSignal);
+Deno.addSignalListener("SIGTERM", onSignal);
+
+try {
+  await runAsyncOperationScheduler(
+    { connectionString: resolvedDbUrl, max: 4 },
+    { ...options, signal: controller.signal },
+  );
+  logger.info("Async-operation scheduler stopped.");
+} catch (err) {
+  logger.error("Async-operation scheduler failed: {error}", { error: err });
+  Deno.exit(1);
+}

--- a/apps/fsm-core-worker-ts/src/index.ts
+++ b/apps/fsm-core-worker-ts/src/index.ts
@@ -41,6 +41,12 @@ export {
   SCHEDULER_NOTIFY_CHANNEL,
 } from "./fsmscheduler/fsmscheduler.ts";
 export {
+  ASYNC_OPERATION_SCHEDULER_NOTIFY_CHANNEL,
+  asyncOperationScheduleNextPending,
+  runAsyncOperationScheduler,
+} from "./asyncOperationScheduler/asyncOperationScheduler.ts";
+export type { AsyncOperationSchedulerOptions } from "./asyncOperationScheduler/asyncOperationScheduler.ts";
+export {
   deregisterFsmlet,
   fsmletHeartbeat,
   listActiveFsmlets,

--- a/apps/fsm-core-worker-ts/src/logger.ts
+++ b/apps/fsm-core-worker-ts/src/logger.ts
@@ -20,6 +20,7 @@ export async function configureWorkerLogger(
       [CATEGORY.worker]: lowestLevel,
       [CATEGORY.fsmlet]: lowestLevel,
       [CATEGORY.compiler]: lowestLevel,
+      [CATEGORY.scheduler]: lowestLevel,
     },
   });
 }

--- a/packages/fsm-logging-ts/src/categories.ts
+++ b/packages/fsm-logging-ts/src/categories.ts
@@ -7,6 +7,7 @@ export const CATEGORY = {
   db: "@pgfsm/db",
   compiler: "@pgfsm/compiler",
   fsmlet: "@pgfsm/fsmlet",
+  scheduler: "@pgfsm/scheduler",
 } as const;
 
 export type Category = typeof CATEGORY[keyof typeof CATEGORY];


### PR DESCRIPTION
Closes #11

## What

Adds the missing control-plane scheduler for async-operation workerlets — the kube-scheduler equivalent that was already in place for FSM dispatch (`fsmscheduler`), but absent on the async-operation side, so enqueued async operations were never assigned to workerlets.

- **`apps/fsm-core-worker-ts/src/asyncOperationScheduler/asyncOperationScheduler.ts`** — mirrors `fsmscheduler/fsmscheduler.ts`: LISTENs on `async_operation_scheduler_work` (the channel `enqueueAsyncOperationDispatch` notifies), drains the queue via `asyncOperationScheduleNextPending` (→ `fsm_core.async_operation_schedule_next_pending()`) until empty or no workerlet has capacity, with a 30 s fallback poll and graceful shutdown.
- **`apps/fsm-core-worker-ts/src/cli/async-operation-scheduler.ts`** — CLI entry mirroring `cli/fsmscheduler.ts` (`--db-url`, `--poll-interval`, `--stale-threshold`, double-Ctrl+C force exit).
- **`src/index.ts`** — exports `runAsyncOperationScheduler`, `ASYNC_OPERATION_SCHEDULER_NOTIFY_CHANNEL`, `asyncOperationScheduleNextPending`, `AsyncOperationSchedulerOptions`.
- **Logging fix**: added `CATEGORY.scheduler` (`@pgfsm/scheduler`) to `@pgfsm/logging` and wired it into `configureWorkerLogger` — both scheduler CLIs previously emitted nothing because the category was never configured at the composition root.

## Verification

- `deno check` on the new files passes; `deno fmt --check` and `deno lint` clean. (`deno task check` has 2 pre-existing failures on `main` — missing `fsmlet/bootstrap-fsm-modules.ts` and a type mismatch in `create-and-start-promise-worker.ts` — unrelated to this change.)
- E2E against local Supabase: CLI starts, LISTENs on `async_operation_scheduler_work`; `pg_notify` triggers a scheduling cycle immediately; with a registered workerlet and a pending dispatch entry, the entry transitions `pending` → `scheduled` with the workerlet assigned and `scheduled_at` set; SIGTERM shuts down gracefully ("Async-operation scheduler stopped").
- Testing surfaced a pre-existing DB bug that blocks the full dispatch path: the per-workerlet notify channel name exceeds PostgreSQL's 63-byte limit, so `async_operation_schedule_next_pending` always errors when a workerlet is available — filed as #12 (E2E above was run with a locally patched short prefix, then the checked-in definition was restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)