### PR TITLE
fix(db): shorten async-op workerlet notify channel to fit PG's 63-byte limit

### DIFF
--- a/apps/fsm-core-worker-ts/src/asyncOperationWorkerlet/asyncOperationWorkerlet.ts
+++ b/apps/fsm-core-worker-ts/src/asyncOperationWorkerlet/asyncOperationWorkerlet.ts
@@ -151,7 +151,7 @@ async function startPromiseWorkerForLang(
  *   1. validateAsyncOperationFromFoldersV2 to discover and verify actors.
  *   2. Load each verified async operation into async_operation_meta via loadAsyncOperation.
  *   3. Registers itself in async_operation_workerlet with the full supported-op list.
- *   4. Opens a dedicated LISTEN connection on async_operation_workerlet_work_<id>.
+ *   4. Opens a dedicated LISTEN connection on async_op_workerlet_work_<id>.
  *   5. On each notify: claimScheduledForAsyncOperationWorkerlet() atomically, then
  *      starts a long-running promise worker for that actor queue (one per queue).
  *   6. Heartbeat every 5 s + fallback poll every 30 s to catch missed notifications.

--- a/packages/database-src/database.types.ts
+++ b/packages/database-src/database.types.ts
@@ -728,6 +728,12 @@ export type Database = {
         };
         Returns: Json;
       };
+      claim_scheduled_for_async_operation_workerlet: {
+        Args: {
+          input_workerlet_id: string;
+        };
+        Returns: Json;
+      };
       claim_scheduled_for_fsmlet: {
         Args: {
           input_fsmlet_id: string;

--- a/packages/database-src/package-lock.json
+++ b/packages/database-src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fsm_core",
-  "version": "1.1.3",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsm_core",
-      "version": "1.1.3",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.97.0",

--- a/packages/database-src/package.json
+++ b/packages/database-src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm_core",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "This package is used for the main PostgreSQL files for the FSM project.",
   "main": "index.js",
   "scripts": {

--- a/packages/database-src/supabase/migrations/20260715024919_fsm_core--1.2.1--1.2.2.sql
+++ b/packages/database-src/supabase/migrations/20260715024919_fsm_core--1.2.1--1.2.2.sql
@@ -1,19 +1,35 @@
--- fsm_core.async_operation_schedule_next_pending
--- Atomically claims the oldest pending dispatch entry, selects the best
--- available async-operation workerlet (filter: heartbeat fresh + supports this
--- specific async operation + has a free slot; score: most free slots), assigns
--- the entry, and notifies the workerlet via pg_notify — all in one transaction.
---
--- Returns TRUE if an entry was scheduled, FALSE if the queue is empty or
--- no workerlet has capacity. Safe to call from multiple scheduler replicas
--- concurrently — FOR UPDATE SKIP LOCKED prevents double-assignment.
+set check_function_bodies = off;
 
-CREATE OR REPLACE FUNCTION fsm_core.async_operation_schedule_next_pending(
-  input_stale_threshold_seconds int DEFAULT 30
-)
-RETURNS boolean
-LANGUAGE plpgsql
-AS $$
+CREATE OR REPLACE FUNCTION fsm_core.claim_scheduled_for_async_operation_workerlet(input_workerlet_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_result jsonb;
+BEGIN
+  WITH claimed AS (
+    DELETE FROM fsm_core.async_operation_instance_and_async_operation_workerlet
+    WHERE async_operation_instance_and_async_operation_workerlet_id = (
+      SELECT async_operation_instance_and_async_operation_workerlet_id
+      FROM fsm_core.async_operation_instance_and_async_operation_workerlet
+      WHERE status = 'scheduled'
+        AND async_operation_workerlet_id = input_workerlet_id
+      ORDER BY scheduled_at
+      FOR UPDATE SKIP LOCKED
+      LIMIT 1
+    )
+    RETURNING *
+  )
+  SELECT row_to_json(claimed.*)::jsonb INTO v_result FROM claimed;
+  RETURN v_result;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION fsm_core.async_operation_schedule_next_pending(input_stale_threshold_seconds integer DEFAULT 30)
+ RETURNS boolean
+ LANGUAGE plpgsql
+AS $function$
 DECLARE
   v_entry_id                  uuid;
   v_instance_id               uuid;
@@ -94,4 +110,52 @@ BEGIN
 
   RETURN true;
 END;
-$$;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION fsm_core.load_async_operation_meta_v2(input_async_operation_name text, input_async_operation_version text, input_async_operation_type text, input_async_operation_language text, input_parent_fsm_name text, input_parent_fsm_version text, input_updated_by_pid text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_result jsonb;
+BEGIN
+  INSERT INTO fsm_core.async_operation_meta (
+    async_operation_name,
+    async_operation_version,
+    async_operation_type,
+    async_operation_language,
+    parent_fsm_name,
+    parent_fsm_version,
+    updated_by_pid
+  ) VALUES (
+    input_async_operation_name,
+    input_async_operation_version,
+    input_async_operation_type,
+    input_async_operation_language,
+    input_parent_fsm_name,
+    input_parent_fsm_version,
+    input_updated_by_pid
+  )
+  ON CONFLICT ON CONSTRAINT async_operation_meta_unique
+  DO UPDATE SET
+    updated_at             = now(),
+    updated_by_pid         = input_updated_by_pid
+  RETURNING jsonb_build_object(
+    'async_operation_meta_id',async_operation_meta_id,
+    'async_operation_name',   async_operation_name,
+    'async_operation_version', async_operation_version,
+    'async_operation_type',   async_operation_type,
+    'async_operation_language', async_operation_language,
+    'parent_fsm_name',        parent_fsm_name,
+    'parent_fsm_version',     parent_fsm_version,
+    'updated_at',             updated_at,
+    'updated_by_pid',         updated_by_pid
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$
+;
+
+

--- a/packages/fsm-core-db-ts/src/async-operation-workerlet.ts
+++ b/packages/fsm-core-db-ts/src/async-operation-workerlet.ts
@@ -30,7 +30,10 @@ export type AsyncOpDispatchEntry = {
 export function asyncOperationWorkerletNotifyChannel(
   workerletId: string,
 ): string {
-  return `async_operation_workerlet_work_${workerletId}`;
+  // Prefix must keep prefix + uuid within PostgreSQL's 63-byte channel-name
+  // limit (LISTEN silently truncates above it). Must match the pg_notify in
+  // fsm_core.async_operation_schedule_next_pending.
+  return `async_op_workerlet_work_${workerletId}`;
 }
 
 export async function registerAsyncOperationWorkerlet(


### PR DESCRIPTION
Closes #12

## What

`'async_operation_workerlet_work_' || <uuid>` is 67 chars. PostgreSQL caps notification channel names at 63 bytes: `pg_notify()` raises `channel name too long` (22023) above it — rolling back every assignment inside `fsm_core.async_operation_schedule_next_pending` — while the workerlet's `LISTEN` silently truncates the identifier. The async-operation dispatch path could never complete.

Renamed the prefix to `async_op_workerlet_work_` (24 + 36 = 60 chars) on both sides:

- `packages/database-src/supabase/schemas/20241218134639_async_operation_schedule_next_pending.sql` — source-of-truth schema, with a comment noting the 63-byte constraint
- `packages/fsm-core-db-ts/src/async-operation-workerlet.ts` — `asyncOperationWorkerletNotifyChannel`
- doc comment in `apps/fsm-core-worker-ts/src/asyncOperationWorkerlet/asyncOperationWorkerlet.ts`

Migration `20260715024919_fsm_core--1.2.1--1.2.2.sql` was generated via the documented `supabase:restart:with:diff:withUpgradeScript:temp` flow (bumps `fsm_core` 1.2.1 → 1.2.2, regenerates `database.types.ts`). The generated diff also captured `claim_scheduled_for_async_operation_workerlet` and `load_async_operation_meta_v2`, whose schema files had drifted ahead of the migration history — content is identical to `supabase/schemas/`. `pgxn-dist/` is untouched (updated by the separate publish flow).

## Verification

Against a from-scratch local Supabase (all migrations applied):

- Before: `SELECT fsm_core.async_operation_schedule_next_pending(30)` with a registered workerlet + pending entry → `ERROR: channel name too long`, entry stuck `pending`.
- After: returns `true`; a session LISTENing on `async_op_workerlet_work_<uuid>` receives the notification with the instance-id payload; entry transitions to `scheduled` with the workerlet assigned. Test rows cleaned up afterwards.
- `deno check` passes on `fsm-core-db-ts`; workspace `deno fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)