### PR TITLE
chore(ci): fix CLA allowlist casing to match GitHub login

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,7 +32,9 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/${{ github.repository }}/blob/main/CLA.md
           branch: cla-signatures
-          allowlist: nirajkashyap
+          # The allowlist match is case-sensitive against the GitHub login;
+          # keep both casings so a login-case mismatch never flags the owner.
+          allowlist: Nirajkashyap,nirajkashyap
 
           create-file-commit-message: "docs: store CLA signatures"
           signed-commit-message: "docs: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo"


### PR DESCRIPTION
## Summary

The `cla-assistant` check has failed on every PR to this repo. Root cause: the commit-author email resolves to the GitHub login `Nirajkashyap`, but `cla.yml` had `allowlist: nirajkashyap` — and the contributor-assistant action's allowlist comparison is case-sensitive, so the repo owner was flagged as an unsigned committer every time.

This keeps both casings in the allowlist so a login-case mismatch never flags the owner. (`Co-Authored-By` trailers were ruled out as the cause — the action only inspects each commit's resolved author, never co-author trailers.)

## After merging

`cla.yml` runs on `pull_request_target`, so the workflow is read from the **base** branch. The fix takes effect only once this lands on `main`; then comment `recheck` on any open PR (e.g. #16) to turn its stale cla-assistant failure green.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)