### PR TITLE
fix(worker): fsmlet fsm_modules key-casing mismatch stalls dispatch at pending

### DIFF
--- a/apps/fsm-core-worker-ts/src/fsmlet/fsmlet.ts
+++ b/apps/fsm-core-worker-ts/src/fsmlet/fsmlet.ts
@@ -232,8 +232,8 @@ export async function startFsmlet(
       // Step 4: Registers itself with valid FSM modules in fsm_workerlet.
       const verifiedFsmWithAsyncOpsToBeRegistered: FsmModule[] =
         verifiedFsmWithAsyncOps.map((m) => ({
-          fsmName: m.fsmName,
-          fsmVersion: m.fsmVersion,
+          fsm_name: m.fsmName,
+          fsm_version: m.fsmVersion,
         }));
       await registerFsmlet(
         deps,

--- a/packages/fsm-core-db-ts/src/fsm-workerlet.ts
+++ b/packages/fsm-core-db-ts/src/fsm-workerlet.ts
@@ -9,7 +9,7 @@ const SCHEDULE_NEXT_PENDING_FN = `${FSM_SCHEMA}.schedule_next_pending`;
 const CLAIM_SCHEDULED_FOR_FSMLET_FN =
   `${FSM_SCHEMA}.claim_scheduled_for_fsmlet`;
 
-export type FsmModule = { fsmName: string; fsmVersion: string };
+export type FsmModule = { fsm_name: string; fsm_version: string };
 
 export function fsmletNotifyChannel(fsmletId: string): string {
   return `fsm_fsmlet_work_${fsmletId}`;


### PR DESCRIPTION
## Summary
- `registerFsmlet` serialized `fsm_workerlet.fsm_modules` as `{fsmName, fsmVersion}` (camelCase), but `fsm_core.schedule_next_pending`'s `jsonb @>` containment check tests for `{fsm_name, fsm_version}` (snake_case). Exact-key jsonb containment never matched, so `schedule_next_pending` always returned `false` and every FSM dispatch row stayed at `status='pending'` forever, silently — no error anywhere.
- Fix aligns the TS side (`FsmModule` type + the one construction site in `fsmlet.ts`) to the column's documented snake_case shape, matching the convention already used on the async-operation side. No SQL/migration change needed.

## Test plan
- [x] `deno check apps/fsm-core-worker-ts/src/index.ts` — pre-existing unrelated type error confirmed present on `main` too (unrelated to this change); no new errors introduced.
- [x] `deno check packages/fsm-core-db-ts/src/index.ts` — clean.
- [ ] Manual verification against a live DB: start `fsmlet` + `fsmscheduler`, run `fsmctl create -n creditCheck -v v02`, confirm the dispatch row transitions `pending` → `scheduled` → claimed instead of sticking at `pending`.

Closes #23