### PR TITLE
fix(worker): default-create fsm_instance pgmq queue and surface DB-layer worker logs

### DIFF
--- a/apps/fsm-core-ts-hono-deno/routes/fsm/fsm.handlers.dispatch.ts
+++ b/apps/fsm-core-ts-hono-deno/routes/fsm/fsm.handlers.dispatch.ts
@@ -30,15 +30,16 @@ export const createAndDispatch: AppRouteHandler<CreateAndDispatchRoute> =
         );
       }
 
-      // false = do not auto-create a pgmq queue; create_fsm_instance_from_name_v2
-      // already enqueues to fsm_dispatch_queue and notifies the fsmscheduler
-      // internally — no separate enqueueDispatch call needed here.
+      // true = also create the instance's pgmq queue and send
+      // initialTransition_event; the fsm_dispatch_queue enqueue alone only gets
+      // a worker started for this instance — the worker then reads from the
+      // per-instance pgmq queue, so that queue must exist and have a message.
       const fsm_instance = await createFsmInstanceFromName(
         deps,
         input_fsm_name,
         input_fsm_version,
         input_fsm_context as Json,
-        false,
+        true,
       ) as Record<string, string> | null;
 
       if (!fsm_instance?.fsm_instance_id) {

--- a/apps/fsm-core-worker-ts/src/cli/fsmctl.ts
+++ b/apps/fsm-core-worker-ts/src/cli/fsmctl.ts
@@ -134,15 +134,16 @@ try {
       }
       const pool = new Pool({ connectionString: resolvedDbUrl });
       const deps = { db: pool, useSupabase: false };
-      // false = do not auto-create a pgmq queue; create_fsm_instance_from_name_v2
-      // already enqueues to fsm_dispatch_queue and notifies the fsmscheduler
-      // internally — no separate enqueueDispatch call needed here.
+      // true = also create the instance's pgmq queue and send
+      // initialTransition_event; the fsm_dispatch_queue enqueue alone only gets
+      // a worker started for this instance — the worker then reads from the
+      // per-instance pgmq queue, so that queue must exist and have a message.
       const result = await createFsmInstanceFromName(
         deps,
         fsmName!,
         fsmVersion!,
         context,
-        false,
+        true,
       ) as Record<string, string> | null;
       if (!result?.fsm_instance_id) {
         await pool.end();
@@ -150,7 +151,7 @@ try {
         Deno.exit(1);
       }
       await pool.end();
-      logger.info(result.fsm_instance_id);
+      logger.info("Created FSM instance: {result}", { result });
       break;
     }
 

--- a/apps/fsm-core-worker-ts/src/logger.ts
+++ b/apps/fsm-core-worker-ts/src/logger.ts
@@ -9,8 +9,9 @@ export type { LogLevel };
 
 // Composition root for the worker CLIs: configures LogTape once. On a TTY it
 // runs at debug for the rich summary view; piped output stays at the given
-// level. Surfaces the worker/fsmlet/compiler namespaces this process hosts —
-// add CATEGORY.db here to also see DB-layer logs.
+// level. Surfaces the worker/fsmlet/db/compiler namespaces this process
+// hosts — CATEGORY.db is required so errors from the DB layer (e.g. reading
+// from a queue that doesn't exist) aren't silently dropped by LogTape.
 export async function configureWorkerLogger(
   level: LogLevel = "info",
 ): Promise<void> {
@@ -19,6 +20,7 @@ export async function configureWorkerLogger(
     levels: {
       [CATEGORY.worker]: lowestLevel,
       [CATEGORY.fsmlet]: lowestLevel,
+      [CATEGORY.db]: lowestLevel,
       [CATEGORY.compiler]: lowestLevel,
       [CATEGORY.scheduler]: lowestLevel,
     },

--- a/packages/database-src/supabase/migrations/20260717142900_fsm_core--1.2.3--1.2.4.sql
+++ b/packages/database-src/supabase/migrations/20260717142900_fsm_core--1.2.3--1.2.4.sql
@@ -1,0 +1,111 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION fsm_core.create_fsm_instance_from_name_v2(input_fsm_name text, input_fsm_version text, input_fsm_context jsonb, create_pgmq_queue boolean DEFAULT true)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    output_queue_created boolean := false;
+    output_message text := NULL;
+    output_extra_message text := NULL;
+    fsm_instance_id uuid;
+    send_event_result jsonb := NULL;
+    derived_fsm_type text;
+    fsm_instance_row      fsm_core.fsm_instance;
+BEGIN
+    -- 1. Check if fsm_name and fsm_version exist in fsm_core.fsm_json and get fsm_type
+    SELECT fj.fsm_type INTO derived_fsm_type
+    FROM fsm_core.fsm_json fj
+    WHERE fj.fsm_name = input_fsm_name AND fj.fsm_version = input_fsm_version;
+
+    IF derived_fsm_type IS NULL THEN
+        RAISE EXCEPTION 'FSM with name % and version % not found in fsm_core.fsm_json', input_fsm_name, input_fsm_version;
+    END IF;
+
+    -- 2. Create new fsm_instance
+    INSERT INTO fsm_core.fsm_instance (fsm_name, fsm_version, fsm_type, fsm_instance_context)
+    VALUES (input_fsm_name, input_fsm_version, derived_fsm_type, input_fsm_context)
+    RETURNING * INTO fsm_instance_row;
+
+    fsm_instance_id := fsm_instance_row.id;
+
+    -- 3. Insert all transitions into fsm_core.fsm_instance_transitions_auth
+    INSERT INTO fsm_core.fsm_instance_transitions_auth (
+        fsm_name, fsm_version, fsm_type, fsm_instance_id, fsm_instance_event_type, users, groups, module_tag, meta_info
+    )
+    SELECT
+        t.fsm_name,
+        t.fsm_version,
+        derived_fsm_type,
+        fsm_instance_id,
+        t.event_type,
+        ARRAY[]::jsonb[], -- users (default empty array)
+        ARRAY[]::jsonb[], -- groups (default empty array)
+        NULL::jsonb,      -- module_tag (default null)
+        NULL::jsonb       -- meta_info (default null)
+    FROM fsm_core.fsm_transitions t
+    WHERE t.fsm_name = input_fsm_name AND t.fsm_version = input_fsm_version;
+
+    -- 4. Enqueue to fsm_instance_and_fsm_workerlet and notify the fsmscheduler.
+    PERFORM fsm_core.enqueue_fsm_dispatch_v2(
+        fsm_instance_id,
+        input_fsm_name,
+        input_fsm_version,
+        'start'
+    );
+
+    -- 5. Optionally create pgmq queue and send initial event
+    IF create_pgmq_queue THEN
+        BEGIN
+            PERFORM pgmq.create(queue_name := fsm_instance_id::text);
+            output_queue_created := true;
+            output_message := 'Queue created successfully.';
+            -- Try to send initialTransition_event to the queue
+            BEGIN
+                send_event_result := fsm_core.send_event_to_fsm_queue_with_event_logs_v2(
+                    input_fsm_instance_id := fsm_instance_id,
+                    input_fsm_instance_id_fsm_type := derived_fsm_type,
+                    input_fsm_instance_id_fsm_version := input_fsm_version,
+                    input_send_to_parent_queue_id := fsm_core.pg_system_queue_uuid(),
+                    input_send_to_parent_queue_type := fsm_core.pg_system_queue_type(),
+                    input_send_to_parent_queue_id_event_name := fsm_core.pg_system_event_name(),
+                    input_event_name := 'initialTransition_event',
+                    input_event_action_type := 'system',
+                    input_event_data := jsonb_build_object('source', 'system'),
+                    input_event_delay := 0,
+                    input_event_status := 'fsm_started',
+                    input_event_output := '{}'::jsonb,
+                    input_error_message := NULL,
+                    input_execution_started_at := now(),
+                    input_execution_duration := NULL,
+                    input_execution_finished_at := now()
+                );
+                output_extra_message := 'initialTransition_event is also sent to queue.';
+            EXCEPTION WHEN OTHERS THEN
+                output_extra_message := SQLERRM;
+            END;
+        EXCEPTION WHEN OTHERS THEN
+            output_queue_created := false;
+            output_message := SQLERRM;
+        END;
+    ELSE
+        output_queue_created := false;
+        output_message := 'queue_created is false and no queue is created.';
+        output_extra_message := NULL;
+    END IF;
+
+    RETURN jsonb_build_object(
+        'queue_created', output_queue_created,
+        'fsm_name', input_fsm_name,
+        'fsm_version', input_fsm_version,
+        'fsm_instance_id', fsm_instance_id,
+        'fsm_instance_context', input_fsm_context,
+        'send_event_result', send_event_result,
+        'message', output_message,
+        'extra_message', output_extra_message
+    );
+END;
+$function$
+;
+
+

--- a/packages/database-src/supabase/schemas/20250219134650_fsm_instance_create_and_send_operation_v2.sql
+++ b/packages/database-src/supabase/schemas/20250219134650_fsm_instance_create_and_send_operation_v2.sql
@@ -117,7 +117,7 @@ CREATE OR REPLACE FUNCTION fsm_core.create_fsm_instance_from_name_v2(
     input_fsm_name text,
     input_fsm_version TEXT,
     input_fsm_context jsonb,
-    create_pgmq_queue boolean DEFAULT false
+    create_pgmq_queue boolean DEFAULT true
 )
 RETURNS JSONB
 AS $$

--- a/packages/fsm-core-db-ts/src/fsm-instance.ts
+++ b/packages/fsm-core-db-ts/src/fsm-instance.ts
@@ -75,7 +75,7 @@ export async function createFsmInstanceFromName(
   input_fsm_version: CreateInstanceArgs["input_fsm_version"],
   input_fsm_context: CreateInstanceArgs["input_fsm_context"],
   create_pgmq_queue: NonNullable<CreateInstanceArgs["create_pgmq_queue"]> =
-    false,
+    true,
 ): Promise<Json> {
   try {
     const text = `


### PR DESCRIPTION
## Summary
- `create_fsm_instance_from_name_v2` defaulted `create_pgmq_queue` to `false`, and the two real callers (`fsmctl create`, `POST /fsm/create-and-dispatch`) hardcoded `false` on the mistaken belief that the `fsm_dispatch_queue` enqueue made it unnecessary. The fsmlet worker actually reads from the **per-instance** pgmq queue, so it was never created and instances silently never progressed past "Started FSM worker for queue...". Default and both call sites now create the queue and send `initialTransition_event`; the TS wrapper's default was updated to match. New patch migration `20260717142900_fsm_core--1.2.3--1.2.4.sql` (hand-authored — the pinned Supabase CLI v2.19.8 doesn't recognize this repo's declarative `db.migrations.schema_paths` config, so `supabase db diff` silently no-ops; worth a separate chore issue).
- `apps/fsm-core-worker-ts/src/logger.ts`'s `configureWorkerLogger` never wired `CATEGORY.db` into LogTape's sinks, so all `@pgfsm/db` logs (e.g. `readMessage`'s caught "queue does not exist" error) were silently dropped — no sink in the category chain, no throw, no warning. That's why nothing printed after the worker's startup log line. Now included, matching the API server's logger config.
- `fsmctl create` now logs the full structured result instead of just `result.fsm_instance_id`.
- Confirmed (no change needed): the internal `await startFSMWorker(...)` inside `startFSMWorkerWithDBLock` is correct — needed for its try/catch/finally to release the DB lock. The concurrency-relevant call site (`fsmlet.ts`'s `processNextWork`) already correctly fire-and-forgets with `.then/.catch/.finally`.

## Test plan
- [x] Verified directly against a reset local Supabase DB: calling `create_fsm_instance_from_name_v2` with no 4th arg now returns `"queue_created": true` and sends `initialTransition_event` (previously required explicitly passing `true`).
- [x] `supabase db reset` applies the new migration cleanly; `pg_get_functiondef` on the live DB confirms `create_pgmq_queue boolean DEFAULT true`.
- [x] `npm run supabase:gen:types` + `deno fmt` regenerated against the fixed DB — byte-identical to the committed `database.types.ts` (the default value isn't encoded in the generated type, only optionality, so no type changes needed).
- [x] `deno check` on all edited files — no new errors; the one pre-existing typecheck error in the workspace (`create-and-start-promise-worker.ts`) is unrelated and present on `main` too.
- [ ] Live worker run against a real FSM (e.g. `creditCheck`) — not exercised in this session (no FSM was loaded into the fresh local DB); recommend a smoke test via `fsmctl create` before merging if you want end-to-end confidence beyond the direct SQL-level verification above.

Closes #25