### PR TITLE
test(database): add pgTAP test suite for supabase/schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,40 @@ jobs:
       # pgrx crates gate their PG version behind a feature; clippy needs one selected.
       - name: Clippy
         run: cargo clippy --features pg15 --no-default-features -- -D warnings
+
+  database:
+    name: Database (pgTAP)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/database-src
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Installs proto and runs `proto install` against the root .prototools.
+      - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
+        with:
+          auto-install: true
+
+      # moonrepo/setup-toolchain only resolves the root .prototools (Deno).
+      # Node is pinned separately in packages/database-src/.prototools, so run
+      # `proto install` again scoped to this directory to pick that pin up too.
+      - name: Install Node (from packages/database-src/.prototools)
+        run: proto install
+
+      - name: npm install
+        run: npm install
+
+      # Full local Supabase stack (Postgres + gotrue + storage + pgmq, etc.) via
+      # Docker, which ubuntu-latest already has. First pull is several GB and
+      # takes a couple of minutes — no image-layer caching here yet.
+      - name: Start local Supabase
+        run: npm run supabase:start
+
+      # Compiles supabase/schemas/*.sql into migrations and applies them.
+      - name: Apply schema (db reset)
+        run: npm run supabase:db:reset
+
+      # Runs the pgTAP suite in supabase/tests/ (see docs/guides/development.md).
+      - name: Run pgTAP tests
+        run: npm run supabase:test:db

--- a/packages/database-src/docs/guides/development.md
+++ b/packages/database-src/docs/guides/development.md
@@ -44,6 +44,35 @@ npm run supabase:db:addfakeusers
 npm run supabase:db:deletefakeusers
 ```
 
+## Testing (pgTAP)
+
+Tests live in `supabase/tests/` — the directory name the Supabase CLI's pgTAP
+runner hardcodes (`supabase test db` mounts `supabase/tests` directly; it can't
+be pointed at an arbitrarily named folder). One file per file in
+`supabase/schemas/`, sharing the same basename (e.g.
+`schemas/20241218134636_fsm_advisory_lock_helper.sql` →
+`tests/20241218134636_fsm_advisory_lock_helper.sql`). `tests/000_setup.sql`
+bootstraps the `pgtap` extension and always runs first (pg_prove executes files
+in alphabetical order).
+
+```bash
+# Local Supabase must already be running (npm run supabase:start:env)
+npm run supabase:test:db
+```
+
+Each test file wraps its assertions in `begin; ... rollback;` so behavioral
+tests never leave data behind in the shared local dev database. Two tiers,
+applied depending on what the schema file defines:
+
+- **Structural** (`has_table`, `has_column`, `col_type_is`, `has_function`,
+  `has_trigger`, `has_type`) — for every schema file, proving the objects it
+  creates exist with the right shape.
+- **Behavioral** (`results_eq`, `throws_ok`, `lives_ok`) — for files with real
+  logic, exercising representative inputs/outputs.
+
+The 5 fully-commented-out reference/changelog files in `supabase/schemas/` (no
+live objects) intentionally have no matching test file.
+
 ## Making schema changes (day-to-day)
 
 Schema source files live in `supabase/schemas/` — they are the source of truth.

--- a/packages/database-src/package.json
+++ b/packages/database-src/package.json
@@ -22,6 +22,7 @@
     "supabase:gen:types": "supabase gen types typescript --local --schema public,fsm_core,pgmq > database.types.ts",
     "supabase:db:addfakeusers": "tsx create-fake-user.ts",
     "supabase:db:deletefakeusers": "tsx delete-fake-user.ts",
+    "supabase:test:db": "supabase test db",
     "supabase:restart:with:diff:withUpgradeScript:patch": "npm run supabase:stop && npm run supabase:docker:volume:clean && npm run supabase:db:diff:schemafolder:sql:withUpgradeScript:patch && npm run supabase:start:env && npm run supabase:gen:types",
     "supabase:restart:with:diff:withUpgradeScript:minor": "npm run supabase:stop && npm run supabase:docker:volume:clean && npm run supabase:db:diff:schemafolder:sql:withUpgradeScript:minor && npm run supabase:start:env && npm run supabase:gen:types",
     "supabase:restart:with:diff:withUpgradeScript:major": "npm run supabase:stop && npm run supabase:docker:volume:clean && npm run supabase:db:diff:schemafolder:sql:withUpgradeScript:major && npm run supabase:start:env && npm run supabase:gen:types",

--- a/packages/database-src/supabase/tests/000_setup.sql
+++ b/packages/database-src/supabase/tests/000_setup.sql
@@ -1,0 +1,12 @@
+-- pgTAP bootstrap. Runs first (pg_prove executes files in alphabetical
+-- order). Not part of supabase/schemas/ on purpose: pgtap is a test-only
+-- dependency, and schemas/ is the declarative prod schema compiled by
+-- `supabase db diff`. Idempotent so it self-heals after `supabase db reset`.
+--
+-- No begin/rollback wrapper here: CREATE EXTENSION must commit so the
+-- extension is actually available to every subsequent test file.
+create extension if not exists pgtap with schema extensions;
+
+select plan(1);
+select pass('pgtap extension bootstrap complete');
+select * from finish();

--- a/packages/database-src/supabase/tests/20241218134623_supabase_only_pre_migrations_fsm_core_extension_prerequisites.sql
+++ b/packages/database-src/supabase/tests/20241218134623_supabase_only_pre_migrations_fsm_core_extension_prerequisites.sql
@@ -1,0 +1,8 @@
+begin;
+select plan(2);
+
+select has_extension('ltree', 'ltree extension is installed');
+select has_extension('pgmq', 'pgmq extension is installed (bundled by default in Supabase/Postgres)');
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134632_pre_migrations_fsm_core_extension_init.sql
+++ b/packages/database-src/supabase/tests/20241218134632_pre_migrations_fsm_core_extension_init.sql
@@ -1,0 +1,13 @@
+begin;
+select plan(4);
+
+select has_schema('fsm_core', 'fsm_core schema exists');
+select has_extension('pg_jsonschema', 'pg_jsonschema extension is installed');
+select has_function('fsm_core', 'hello', ARRAY['text'], 'fsm_core.hello(text) exists');
+select lives_ok(
+  $$ select fsm_core.hello('world') $$,
+  'fsm_core.hello(text) runs without error'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134635_fsm_module_config.sql
+++ b/packages/database-src/supabase/tests/20241218134635_fsm_module_config.sql
@@ -1,0 +1,69 @@
+begin;
+select plan(29);
+
+-- Tier 1: structural — composite types
+select has_type('fsm_core', 'fsm_event_data_v2', 'fsm_core.fsm_event_data_v2 type exists');
+select has_column('fsm_core', 'fsm_event_data_v2', 'eventType', 'fsm_event_data_v2.eventType exists');
+select has_column('fsm_core', 'fsm_event_data_v2', 'eventPayload', 'fsm_event_data_v2.eventPayload exists');
+select has_column('fsm_core', 'fsm_event_data_v2', 'actionType', 'fsm_event_data_v2.actionType exists');
+
+select has_type('fsm_core', 'fsm_queue_msg_data_v2', 'fsm_core.fsm_queue_msg_data_v2 type exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'eventData', 'fsm_queue_msg_data_v2.eventData exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'queueId', 'fsm_queue_msg_data_v2.queueId exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'queueType', 'fsm_queue_msg_data_v2.queueType exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'queueVersion', 'fsm_queue_msg_data_v2.queueVersion exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'sendToParentQueueId', 'fsm_queue_msg_data_v2.sendToParentQueueId exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'sendToParentQueueType', 'fsm_queue_msg_data_v2.sendToParentQueueType exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'sendToParentQueueIdEventName', 'fsm_queue_msg_data_v2.sendToParentQueueIdEventName exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'queueMsgId', 'fsm_queue_msg_data_v2.queueMsgId exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'queueMsgDelay', 'fsm_queue_msg_data_v2.queueMsgDelay exists');
+select has_column('fsm_core', 'fsm_queue_msg_data_v2', 'queueFnName', 'fsm_queue_msg_data_v2.queueFnName exists');
+
+-- Tier 1: structural — functions
+select has_function('fsm_core', 'fsm_json_schema', 'fsm_core.fsm_json_schema() exists');
+select has_function('fsm_core', 'pg_system_queue_uuid', 'fsm_core.pg_system_queue_uuid() exists');
+select has_function('fsm_core', 'pg_system_queue_type', 'fsm_core.pg_system_queue_type() exists');
+select has_function('fsm_core', 'pg_system_event_name', 'fsm_core.pg_system_event_name() exists');
+select has_function('fsm_core', 'api_system_queue_uuid', 'fsm_core.api_system_queue_uuid() exists');
+select has_function('fsm_core', 'api_system_queue_type', 'fsm_core.api_system_queue_type() exists');
+select has_function('fsm_core', 'api_system_event_name', 'fsm_core.api_system_event_name() exists');
+
+-- Tier 2: behavioral — sentinel constants and JSON schema shape
+select results_eq(
+  $$ select fsm_core.fsm_json_schema() ->> 'type' $$,
+  $$ values ('object'::text) $$,
+  'fsm_json_schema() top-level "type" is "object"'
+);
+select results_eq(
+  $$ select fsm_core.pg_system_queue_uuid() $$,
+  $$ values ('00000000-0000-0000-0000-000000000000'::uuid) $$,
+  'pg_system_queue_uuid() is the all-zero sentinel UUID'
+);
+select results_eq(
+  $$ select fsm_core.pg_system_queue_type() $$,
+  $$ values ('POSTGRES_INTERNAL'::text) $$,
+  'pg_system_queue_type() is POSTGRES_INTERNAL'
+);
+select results_eq(
+  $$ select fsm_core.pg_system_event_name() $$,
+  $$ values ('POSTGRES_INTERNAL_EVENT'::text) $$,
+  'pg_system_event_name() is POSTGRES_INTERNAL_EVENT'
+);
+select results_eq(
+  $$ select fsm_core.api_system_queue_uuid() $$,
+  $$ values ('00000000-0000-0000-0000-000000000001'::uuid) $$,
+  'api_system_queue_uuid() is the sentinel UUID ending in 1'
+);
+select results_eq(
+  $$ select fsm_core.api_system_queue_type() $$,
+  $$ values ('API_INTERNAL'::text) $$,
+  'api_system_queue_type() is API_INTERNAL'
+);
+select results_eq(
+  $$ select fsm_core.api_system_event_name() $$,
+  $$ values ('API_INTERNAL_EVENT'::text) $$,
+  'api_system_event_name() is API_INTERNAL_EVENT'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134636_fsm_advisory_lock_helper.sql
+++ b/packages/database-src/supabase/tests/20241218134636_fsm_advisory_lock_helper.sql
@@ -1,0 +1,51 @@
+begin;
+select plan(11);
+
+-- Tier 1: structural — the four overloaded wrapper functions exist with the
+-- expected signatures.
+select has_function('fsm_core', 'pg_try_advisory_lock', ARRAY['bigint'],
+  'fsm_core.pg_try_advisory_lock(bigint) exists');
+select has_function('fsm_core', 'pg_try_advisory_lock', ARRAY['integer', 'integer'],
+  'fsm_core.pg_try_advisory_lock(integer, integer) exists');
+select has_function('fsm_core', 'pg_advisory_unlock', ARRAY['bigint'],
+  'fsm_core.pg_advisory_unlock(bigint) exists');
+select has_function('fsm_core', 'pg_advisory_unlock', ARRAY['integer', 'integer'],
+  'fsm_core.pg_advisory_unlock(integer, integer) exists');
+select function_returns('fsm_core', 'pg_try_advisory_lock', ARRAY['bigint'], 'boolean',
+  'pg_try_advisory_lock(bigint) returns boolean');
+
+-- Tier 2: behavioral — the wrappers actually delegate to the underlying
+-- advisory lock primitives (acquire/release semantics), not just the name.
+select results_eq(
+  $$ select fsm_core.pg_try_advisory_lock(123456789::bigint) $$,
+  $$ select true $$,
+  'bigint-key lock acquires on a fresh key'
+);
+select results_eq(
+  $$ select fsm_core.pg_advisory_unlock(123456789::bigint) $$,
+  $$ select true $$,
+  'bigint-key unlock succeeds while held'
+);
+select results_eq(
+  $$ select fsm_core.pg_advisory_unlock(123456789::bigint) $$,
+  $$ select false $$,
+  'bigint-key unlock fails once already released'
+);
+select results_eq(
+  $$ select fsm_core.pg_try_advisory_lock(42, 99) $$,
+  $$ select true $$,
+  'two-int-key lock acquires on a fresh key'
+);
+select results_eq(
+  $$ select fsm_core.pg_advisory_unlock(42, 99) $$,
+  $$ select true $$,
+  'two-int-key unlock succeeds while held'
+);
+select results_eq(
+  $$ select fsm_core.pg_advisory_unlock(42, 99) $$,
+  $$ select false $$,
+  'two-int-key unlock fails once already released'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134637_async_operation_meta.sql
+++ b/packages/database-src/supabase/tests/20241218134637_async_operation_meta.sql
@@ -1,0 +1,61 @@
+begin;
+select plan(18);
+
+-- Tier 1: structural
+select has_table('fsm_core', 'async_operation_meta', 'fsm_core.async_operation_meta exists');
+select col_is_pk('fsm_core', 'async_operation_meta', 'async_operation_meta_id', 'async_operation_meta_id is the primary key');
+select has_column('fsm_core', 'async_operation_meta', 'async_operation_name', 'has async_operation_name column');
+select has_column('fsm_core', 'async_operation_meta', 'async_operation_type', 'has async_operation_type column');
+select has_column('fsm_core', 'async_operation_meta', 'async_operation_version', 'has async_operation_version column');
+select has_column('fsm_core', 'async_operation_meta', 'parent_fsm_name', 'has parent_fsm_name column');
+select has_column('fsm_core', 'async_operation_meta', 'parent_fsm_version', 'has parent_fsm_version column');
+select has_column('fsm_core', 'async_operation_meta', 'max_concurrency', 'has max_concurrency column');
+select has_column('fsm_core', 'async_operation_meta', 'async_operation_language', 'has async_operation_language column');
+select has_column('fsm_core', 'async_operation_meta', 'updated_at', 'has updated_at column');
+select has_column('fsm_core', 'async_operation_meta', 'updated_by_pid', 'has updated_by_pid column');
+select col_is_unique('fsm_core', 'async_operation_meta',
+  ARRAY['async_operation_name', 'async_operation_version', 'async_operation_type', 'parent_fsm_name', 'parent_fsm_version'],
+  'unique constraint covers the five identifying columns');
+select has_function('fsm_core', 'load_async_operation_meta_v2',
+  ARRAY['text', 'text', 'text', 'text', 'text', 'text', 'text'],
+  'fsm_core.load_async_operation_meta_v2(7 x text) exists');
+
+-- Tier 2: behavioral — insert-or-update (upsert) semantics
+select lives_ok(
+  $$ select fsm_core.load_async_operation_meta_v2(
+       'opA', '1', 'internalAsync', 'python', 'fsmA', '1', 'pid-1') $$,
+  'first load_async_operation_meta_v2 call inserts cleanly'
+);
+select results_eq(
+  $$ select (fsm_core.load_async_operation_meta_v2(
+       'opA', '1', 'internalAsync', 'python', 'fsmA', '1', 'pid-2') ->> 'updated_by_pid') $$,
+  $$ values ('pid-2'::text) $$,
+  'second call with the same unique key upserts updated_by_pid'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.async_operation_meta
+     where async_operation_name = 'opA' and async_operation_version = '1'
+       and async_operation_type = 'internalAsync' and parent_fsm_name = 'fsmA'
+       and parent_fsm_version = '1' $$,
+  $$ values (1::bigint) $$,
+  'upsert on the same unique key never duplicates the row'
+);
+select results_eq(
+  $$ select async_operation_language from fsm_core.async_operation_meta
+     where async_operation_name = 'opA' and async_operation_version = '1'
+       and async_operation_type = 'internalAsync' and parent_fsm_name = 'fsmA'
+       and parent_fsm_version = '1' $$,
+  $$ values ('python'::text) $$,
+  'original async_operation_language is retained across the upsert'
+);
+select results_eq(
+  $$ select max_concurrency from fsm_core.async_operation_meta
+     where async_operation_name = 'opA' and async_operation_version = '1'
+       and async_operation_type = 'internalAsync' and parent_fsm_name = 'fsmA'
+       and parent_fsm_version = '1' $$,
+  $$ values (8) $$,
+  'max_concurrency defaults to 8'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134638_async_operation_workerlet.sql
+++ b/packages/database-src/supabase/tests/20241218134638_async_operation_workerlet.sql
@@ -1,0 +1,14 @@
+begin;
+select plan(8);
+
+select has_table('fsm_core', 'async_operation_workerlet', 'fsm_core.async_operation_workerlet exists');
+select col_is_pk('fsm_core', 'async_operation_workerlet', 'async_operation_workerlet_id', 'async_operation_workerlet_id is the primary key');
+select has_column('fsm_core', 'async_operation_workerlet', 'async_operation_workerlet_pid', 'has async_operation_workerlet_pid column');
+select col_type_is('fsm_core', 'async_operation_workerlet', 'supported_async_operations', 'jsonb', 'supported_async_operations is jsonb');
+select has_column('fsm_core', 'async_operation_workerlet', 'max_pid_number', 'has max_pid_number column');
+select has_column('fsm_core', 'async_operation_workerlet', 'active_pid_number', 'has active_pid_number column');
+select has_column('fsm_core', 'async_operation_workerlet', 'last_heartbeat', 'has last_heartbeat column');
+select has_column('fsm_core', 'async_operation_workerlet', 'registered_at', 'has registered_at column');
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134639_async_operation_instance_and_workerlet.sql
+++ b/packages/database-src/supabase/tests/20241218134639_async_operation_instance_and_workerlet.sql
@@ -1,0 +1,36 @@
+begin;
+select plan(15);
+
+select has_table('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'fsm_core.async_operation_instance_and_async_operation_workerlet exists');
+select col_is_pk('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'async_operation_instance_and_async_operation_workerlet_id', 'the surrogate id is the primary key');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'async_operation_instance_id', 'has async_operation_instance_id column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'async_operation_workerlet_id', 'has async_operation_workerlet_id column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'async_operation_name', 'has async_operation_name column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'async_operation_version', 'has async_operation_version column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'async_operation_type', 'has async_operation_type column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'parent_fsm_name', 'has parent_fsm_name column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'parent_fsm_version', 'has parent_fsm_version column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'async_operation_language', 'has async_operation_language column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'status', 'has status column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'created_at', 'has created_at column');
+select has_column('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'scheduled_at', 'has scheduled_at column');
+select has_index('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'idx_async_operation_instance_and_workerlet_pending', 'partial index on pending rows exists');
+select has_index('fsm_core', 'async_operation_instance_and_async_operation_workerlet',
+  'idx_async_operation_instance_and_workerlet_scheduled', 'partial index on scheduled rows exists');
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134640_async_operation_instance_and_workerlet_create_and_stop.sql
+++ b/packages/database-src/supabase/tests/20241218134640_async_operation_instance_and_workerlet_create_and_stop.sql
@@ -1,0 +1,24 @@
+begin;
+select plan(3);
+
+select has_function('fsm_core', 'create_async_operation_instance_and_notify_async_operation_scheduler_work',
+  ARRAY['uuid', 'text', 'text', 'text', 'text', 'text', 'text'],
+  'create_async_operation_instance_and_notify_async_operation_scheduler_work(7 args) exists');
+
+select lives_ok(
+  $$ select fsm_core.create_async_operation_instance_and_notify_async_operation_scheduler_work(
+       '33333333-3333-3333-3333-333333333333'::uuid, 'opCreate', '1', 'internalAsync',
+       'fsmCreate', '1', 'python') $$,
+  'inserts the dispatch row and notifies without error'
+);
+select results_eq(
+  $$ select async_operation_name, async_operation_version, async_operation_type,
+            parent_fsm_name, parent_fsm_version, async_operation_language, status
+     from fsm_core.async_operation_instance_and_async_operation_workerlet
+     where async_operation_instance_id = '33333333-3333-3333-3333-333333333333'::uuid $$,
+  $$ values ('opCreate'::text, '1'::text, 'internalAsync'::text, 'fsmCreate'::text, '1'::text, 'python'::text, 'pending'::text) $$,
+  'inserted row matches inputs and defaults to pending status'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134641_async_operation_schedule_next_pending.sql
+++ b/packages/database-src/supabase/tests/20241218134641_async_operation_schedule_next_pending.sql
@@ -1,0 +1,79 @@
+begin;
+select plan(8);
+
+select has_function('fsm_core', 'async_operation_schedule_next_pending', ARRAY['integer'],
+  'async_operation_schedule_next_pending(integer) exists');
+
+-- Isolate from any pre-existing rows in the shared local dev database; the
+-- outer rollback restores whatever was there before this test ran.
+delete from fsm_core.async_operation_instance_and_async_operation_workerlet;
+delete from fsm_core.async_operation_workerlet;
+
+select results_eq(
+  $$ select fsm_core.async_operation_schedule_next_pending() $$,
+  $$ values (false) $$,
+  'empty dispatch queue: nothing to schedule'
+);
+
+insert into fsm_core.async_operation_instance_and_async_operation_workerlet
+  (async_operation_instance_id, async_operation_name, async_operation_version,
+   async_operation_type, parent_fsm_name, parent_fsm_version, async_operation_language)
+values
+  ('22222222-2222-2222-2222-222222222222'::uuid, 'opY', '1', 'internalAsync', 'fsmY', '1', 'python');
+
+select results_eq(
+  $$ select fsm_core.async_operation_schedule_next_pending() $$,
+  $$ values (false) $$,
+  'pending entry exists but no workerlet is registered: nothing to schedule'
+);
+select results_eq(
+  $$ select status from fsm_core.async_operation_instance_and_async_operation_workerlet
+     where async_operation_instance_id = '22222222-2222-2222-2222-222222222222'::uuid $$,
+  $$ values ('pending'::text) $$,
+  'entry remains pending when no workerlet is available'
+);
+
+-- A workerlet that does not support opY/1/fsmY/1 at all.
+insert into fsm_core.async_operation_workerlet
+  (async_operation_workerlet_id, async_operation_workerlet_pid, supported_async_operations,
+   max_pid_number, active_pid_number, last_heartbeat)
+values
+  ('44444444-4444-4444-4444-444444444444'::uuid, 'pid-other',
+   '[{"async_operation_name": "somethingElse", "async_operation_version": "1", "parent_fsm_name": "fsmY", "parent_fsm_version": "1"}]'::jsonb,
+   8, 0, now());
+
+select results_eq(
+  $$ select fsm_core.async_operation_schedule_next_pending() $$,
+  $$ values (false) $$,
+  'a workerlet that does not support this operation is not chosen'
+);
+
+-- A capable workerlet, but its heartbeat is 60s stale.
+insert into fsm_core.async_operation_workerlet
+  (async_operation_workerlet_id, async_operation_workerlet_pid, supported_async_operations,
+   max_pid_number, active_pid_number, last_heartbeat)
+values
+  ('11111111-1111-1111-1111-111111111111'::uuid, 'pid-capable',
+   '[{"async_operation_name": "opY", "async_operation_version": "1", "parent_fsm_name": "fsmY", "parent_fsm_version": "1"}]'::jsonb,
+   8, 0, now() - interval '60 seconds');
+
+select results_eq(
+  $$ select fsm_core.async_operation_schedule_next_pending(30) $$,
+  $$ values (false) $$,
+  'a capable workerlet with a stale (60s) heartbeat is excluded under the default 30s threshold'
+);
+select results_eq(
+  $$ select fsm_core.async_operation_schedule_next_pending(90) $$,
+  $$ values (true) $$,
+  'the same workerlet is accepted once the staleness threshold is widened to 90s'
+);
+select results_eq(
+  $$ select status, async_operation_workerlet_id
+     from fsm_core.async_operation_instance_and_async_operation_workerlet
+     where async_operation_instance_id = '22222222-2222-2222-2222-222222222222'::uuid $$,
+  $$ values ('scheduled'::text, '11111111-1111-1111-1111-111111111111'::uuid) $$,
+  'a successful schedule assigns the capable workerlet and flips status to scheduled'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134642_fsm_table.sql
+++ b/packages/database-src/supabase/tests/20241218134642_fsm_table.sql
@@ -1,0 +1,68 @@
+begin;
+select plan(45);
+
+-- fsm_core.fsm_json
+select has_table('fsm_core', 'fsm_json', 'fsm_core.fsm_json exists');
+select col_is_pk('fsm_core', 'fsm_json', 'id', 'fsm_json.id is the primary key');
+select col_type_is('fsm_core', 'fsm_json', 'fsm_name', 'text', 'fsm_json.fsm_name is text');
+select col_type_is('fsm_core', 'fsm_json', 'fsm_type', 'text', 'fsm_json.fsm_type is text');
+select col_type_is('fsm_core', 'fsm_json', 'fsm_version', 'text', 'fsm_json.fsm_version is text');
+select col_type_is('fsm_core', 'fsm_json', 'fsm_json', 'jsonb', 'fsm_json.fsm_json is jsonb');
+
+-- fsm_core.fsm_state_type (enum)
+select has_type('fsm_core', 'fsm_state_type', 'fsm_core.fsm_state_type exists');
+select enum_has_labels('fsm_core', 'fsm_state_type',
+  ARRAY['atomic', 'compound', 'parallel', 'final', 'history'],
+  'fsm_state_type has the expected five labels');
+
+-- fsm_core.fsm_states
+select has_table('fsm_core', 'fsm_states', 'fsm_core.fsm_states exists');
+select col_is_pk('fsm_core', 'fsm_states', 'state_id_with_fsm_name_and_fsm_version',
+  'fsm_states.state_id_with_fsm_name_and_fsm_version is the primary key');
+select col_type_is('fsm_core', 'fsm_states', 'state_id_with_fsm_name_and_fsm_version', 'text',
+  'fsm_states.state_id_with_fsm_name_and_fsm_version is text');
+select col_type_is('fsm_core', 'fsm_states', 'id', 'text', 'fsm_states.id is text');
+select col_type_is('fsm_core', 'fsm_states', 'computed_state_id_ltree', 'ltree',
+  'fsm_states.computed_state_id_ltree is ltree');
+select col_type_is('fsm_core', 'fsm_states', 'key', 'text', 'fsm_states.key is text');
+select col_type_is('fsm_core', 'fsm_states', 'computed_state_key_ltree', 'ltree',
+  'fsm_states.computed_state_key_ltree is ltree');
+select col_type_is('fsm_core', 'fsm_states', 'parent_node', 'text', 'fsm_states.parent_node is text');
+select col_type_is('fsm_core', 'fsm_states', 'type', 'fsm_core.fsm_state_type',
+  'fsm_states.type is fsm_core.fsm_state_type');
+select col_type_is('fsm_core', 'fsm_states', 'description', 'text', 'fsm_states.description is text');
+select col_type_is('fsm_core', 'fsm_states', 'fsm_order', 'integer', 'fsm_states.fsm_order is integer');
+select col_type_is('fsm_core', 'fsm_states', 'context', 'jsonb', 'fsm_states.context is jsonb');
+select col_type_is('fsm_core', 'fsm_states', 'states', 'jsonb', 'fsm_states.states is jsonb');
+select col_type_is('fsm_core', 'fsm_states', 'initial', 'jsonb', 'fsm_states.initial is jsonb');
+select col_type_is('fsm_core', 'fsm_states', 'fsm_on', 'jsonb', 'fsm_states.fsm_on is jsonb');
+select col_type_is('fsm_core', 'fsm_states', 'transitions', 'jsonb', 'fsm_states.transitions is jsonb');
+select col_type_is('fsm_core', 'fsm_states', 'entry', 'jsonb', 'fsm_states.entry is jsonb');
+select col_type_is('fsm_core', 'fsm_states', 'exit', 'jsonb', 'fsm_states.exit is jsonb');
+select col_type_is('fsm_core', 'fsm_states', 'invoke', 'jsonb', 'fsm_states.invoke is jsonb');
+select col_type_is('fsm_core', 'fsm_states', 'data', 'jsonb', 'fsm_states.data is jsonb');
+select col_type_is('fsm_core', 'fsm_states', 'history', 'text', 'fsm_states.history is text');
+select col_type_is('fsm_core', 'fsm_states', 'fsm_version', 'text', 'fsm_states.fsm_version is text');
+select col_type_is('fsm_core', 'fsm_states', 'fsm_name', 'text', 'fsm_states.fsm_name is text');
+
+-- fsm_core.fsm_transitions
+select has_table('fsm_core', 'fsm_transitions', 'fsm_core.fsm_transitions exists');
+select col_is_pk('fsm_core', 'fsm_transitions', 'id', 'fsm_transitions.id is the primary key');
+select col_type_is('fsm_core', 'fsm_transitions', 'id', 'integer', 'fsm_transitions.id is integer');
+select col_type_is('fsm_core', 'fsm_transitions', 'actions', 'jsonb', 'fsm_transitions.actions is jsonb');
+select col_type_is('fsm_core', 'fsm_transitions', 'cond', 'jsonb', 'fsm_transitions.cond is jsonb');
+select col_type_is('fsm_core', 'fsm_transitions', 'event_type', 'text', 'fsm_transitions.event_type is text');
+select col_type_is('fsm_core', 'fsm_transitions', 'source', 'text', 'fsm_transitions.source is text');
+select col_type_is('fsm_core', 'fsm_transitions', 'computed_sanitized_source_ltree', 'ltree',
+  'fsm_transitions.computed_sanitized_source_ltree is ltree');
+select col_type_is('fsm_core', 'fsm_transitions', 'target', 'text[]', 'fsm_transitions.target is text[]');
+select col_type_is('fsm_core', 'fsm_transitions', 'computed_sanitized_target_ltree_array', 'ltree[]',
+  'fsm_transitions.computed_sanitized_target_ltree_array is ltree[]');
+select col_type_is('fsm_core', 'fsm_transitions', 'reenter', 'boolean', 'fsm_transitions.reenter is boolean');
+select col_type_is('fsm_core', 'fsm_transitions', 'computed_transition_domain_lca', 'text',
+  'fsm_transitions.computed_transition_domain_lca is text');
+select col_type_is('fsm_core', 'fsm_transitions', 'fsm_name', 'text', 'fsm_transitions.fsm_name is text');
+select col_type_is('fsm_core', 'fsm_transitions', 'fsm_version', 'text', 'fsm_transitions.fsm_version is text');
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134643_fsm_json_helper.sql
+++ b/packages/database-src/supabase/tests/20241218134643_fsm_json_helper.sql
@@ -1,0 +1,208 @@
+begin;
+select plan(35);
+
+-- Tier 1: structural
+select has_function('fsm_core', 'path_string_to_jsonb', ARRAY['text'], 'path_string_to_jsonb(text) exists');
+select has_function('fsm_core', 'jsonb_deep_merge', ARRAY['jsonb', 'jsonb'], 'jsonb_deep_merge(jsonb, jsonb) exists');
+select has_function('fsm_core', 'build_nested_json_recursive', ARRAY['text[]'], 'build_nested_json_recursive(text[]) exists');
+select has_function('fsm_core', 'jsonb_all_paths', ARRAY['jsonb', 'text'], 'jsonb_all_paths(jsonb, text) exists');
+select has_function('fsm_core', 'test_jsonb_roundtrip', ARRAY['jsonb'], 'test_jsonb_roundtrip(jsonb) exists');
+
+-- Tier 2: fsm_core.path_string_to_jsonb
+select results_eq(
+  $$ select fsm_core.path_string_to_jsonb('machine.creditCheck.Entering Information.CheckingCreditScores.CheckingEquiGavin') $$,
+  $$ values ('{"machine": {"creditCheck": {"Entering Information": {"CheckingCreditScores": "CheckingEquiGavin"}}}}'::jsonb) $$,
+  'path_string_to_jsonb builds nested objects from a dotted path'
+);
+select results_eq(
+  $$ select fsm_core.path_string_to_jsonb('') $$,
+  $$ values ('{}'::jsonb) $$,
+  'path_string_to_jsonb('''') returns an empty object'
+);
+select results_eq(
+  $$ select fsm_core.path_string_to_jsonb(NULL) $$,
+  $$ values ('{}'::jsonb) $$,
+  'path_string_to_jsonb(NULL) returns an empty object'
+);
+select results_eq(
+  $$ select fsm_core.path_string_to_jsonb('root') $$,
+  $$ values ('{"root": null}'::jsonb) $$,
+  'a single-segment path becomes {"segment": null}'
+);
+
+-- Tier 2: fsm_core.jsonb_deep_merge
+select results_eq(
+  $$ select fsm_core.jsonb_deep_merge('{"a": "value1"}'::jsonb, '{"a": "value2"}'::jsonb) $$,
+  $$ values ('{"a": "value2"}'::jsonb) $$,
+  'overlapping scalar keys: b wins'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_deep_merge('{"a": {"b": "value1"}}'::jsonb, '{"a": {"c": "value2"}}'::jsonb) $$,
+  $$ values ('{"a": {"b": "value1", "c": "value2"}}'::jsonb) $$,
+  'nested objects with different keys are merged, not replaced'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_deep_merge('{"a": {"b": "value1"}}'::jsonb, '{"a": "value2", "c": {"d": "value3"}}'::jsonb) $$,
+  $$ values ('{"a": {"b": "value1", "value2": null}, "c": {"d": "value3"}}'::jsonb) $$,
+  'merging an object with a scalar folds the scalar in as a null-valued key'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_deep_merge('{"a": "value2"}'::jsonb, NULL) $$,
+  $$ values ('{"a": "value2"}'::jsonb) $$,
+  'merging with NULL b returns a unchanged'
+);
+select is(fsm_core.jsonb_deep_merge(NULL, NULL), NULL, 'merging NULL with NULL returns NULL');
+select results_eq(
+  $$ select fsm_core.jsonb_deep_merge('{"a": "value2"}'::jsonb, '{}'::jsonb) $$,
+  $$ values ('{"a": "value2"}'::jsonb) $$,
+  'merging with an empty object b leaves a unchanged'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_deep_merge('{}'::jsonb, '{}'::jsonb) $$,
+  $$ values ('{}'::jsonb) $$,
+  'merging two empty objects gives an empty object'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_deep_merge('{}'::jsonb, NULL) $$,
+  $$ values ('{}'::jsonb) $$,
+  'merging an empty object with NULL b returns the empty object'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_deep_merge('{"a": "value2"}'::jsonb, '"just a string"'::jsonb) $$,
+  $$ values ('"just a string"'::jsonb) $$,
+  'top-level object merged with a scalar b: b (the scalar) wins entirely'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_deep_merge('"just a string"'::jsonb, '{"a": "value2"}'::jsonb) $$,
+  $$ values ('{"a": "value2"}'::jsonb) $$,
+  'top-level scalar merged with an object b: b (the object) wins entirely'
+);
+
+-- Tier 2: fsm_core.build_nested_json_recursive
+select results_eq(
+  $$ select fsm_core.build_nested_json_recursive(ARRAY[
+       'machine',
+       'machine.creditCheck',
+       'machine.creditCheck.Entering Information',
+       'machine.creditCheck.Entering Information.CheckingCreditScores',
+       'machine.creditCheck.Entering Information.CheckingCreditScores.CheckingEquiGavin'
+     ]) $$,
+  $$ values ('{"machine": {"creditCheck": {"Entering Information": {"CheckingCreditScores": "CheckingEquiGavin"}}}}'::jsonb) $$,
+  'builds a fully nested object from an ordered chain of paths (last segment is a scalar leaf, not {leaf: null})'
+);
+select results_eq(
+  $$ select fsm_core.build_nested_json_recursive(ARRAY['machine']) $$,
+  $$ values ('{"machine": null}'::jsonb) $$,
+  'a single path becomes {"segment": null}'
+);
+select results_eq(
+  $$ select fsm_core.build_nested_json_recursive(ARRAY[
+       'machine', 'machine.creditCheck', 'machine.creditCheck.Entering Information',
+       'machine.creditCheck.CheckingCreditScores'
+     ]) $$,
+  $$ values ('{"machine": {"creditCheck": "CheckingCreditScores"}}'::jsonb) $$,
+  'a shorter sibling path collapses the branch to a scalar leaf (documented current behavior)'
+);
+select results_eq(
+  $$ select fsm_core.build_nested_json_recursive(ARRAY[
+       'machine', 'machine.creditCheck', 'machine.creditCheck.CheckingCreditScores',
+       'machine.creditCheck.CheckingCreditScores.CheckingEquiGavin',
+       'machine.creditCheck.CheckingCreditScores.CheckingGavUnion',
+       'machine.creditCheck.CheckingCreditScores.CheckingGavperian',
+       'machine.creditCheck.CheckingCreditScores.CheckingEquiGavin.CheckingForExistingReport',
+       'machine.creditCheck.CheckingCreditScores.CheckingGavUnion.CheckingForExistingReport',
+       'machine.creditCheck.CheckingCreditScores.CheckingGavperian.CheckingForExisting'
+     ]) $$,
+  $$ values ('{"machine": {"creditCheck": {"CheckingCreditScores": {"CheckingGavUnion": "CheckingForExistingReport", "CheckingEquiGavin": "CheckingForExistingReport", "CheckingGavperian": "CheckingForExisting"}}}}'::jsonb) $$,
+  'a realistic multi-branch path set builds the expected nested tree'
+);
+select results_eq(
+  $$ select fsm_core.build_nested_json_recursive(NULL) $$,
+  $$ values ('{}'::jsonb) $$,
+  'NULL paths array returns an empty object'
+);
+select results_eq(
+  $$ select fsm_core.build_nested_json_recursive(ARRAY['machine', NULL]) $$,
+  $$ values ('{"machine": null}'::jsonb) $$,
+  'NULL elements in the paths array are filtered out'
+);
+select results_eq(
+  $$ select fsm_core.build_nested_json_recursive(ARRAY['', '']) $$,
+  $$ values ('{}'::jsonb) $$,
+  'empty-string-only paths array returns an empty object'
+);
+
+-- Tier 2: fsm_core.jsonb_all_paths
+select results_eq(
+  $$ select fsm_core.jsonb_all_paths('{
+       "creditCheck": {
+         "CheckingCreditScores": {
+           "CheckingEquiGavin": "CheckingForExistingReport",
+           "CheckingGavUnion": "CheckingForExistingReport",
+           "CheckingGavperian": "CheckingForExistingReport"
+         }
+       }
+     }'::jsonb, '') $$,
+  $$ values (ARRAY[
+       'creditCheck',
+       'creditCheck.CheckingCreditScores',
+       'creditCheck.CheckingCreditScores.CheckingGavUnion',
+       'creditCheck.CheckingCreditScores.CheckingGavUnion.CheckingForExistingReport',
+       'creditCheck.CheckingCreditScores.CheckingEquiGavin',
+       'creditCheck.CheckingCreditScores.CheckingEquiGavin.CheckingForExistingReport',
+       'creditCheck.CheckingCreditScores.CheckingGavperian',
+       'creditCheck.CheckingCreditScores.CheckingGavperian.CheckingForExistingReport'
+     ]::text[]) $$,
+  'extracts every intermediate and leaf path with no prefix (jsonb_each order: shortest key first, then lexicographic)'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_all_paths('{"creditCheck": {"CheckingCreditScores": "root"}}'::jsonb, 'root') $$,
+  $$ values (ARRAY[
+       'root.creditCheck',
+       'root.creditCheck.CheckingCreditScores',
+       'root.creditCheck.CheckingCreditScores.root'
+     ]::text[]) $$,
+  'a prefix is prepended to every extracted path (leaf scalar value is appended to its own key path)'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_all_paths('{}'::jsonb, '') $$,
+  $$ values (ARRAY[]::text[]) $$,
+  'an empty object with an empty prefix yields an empty array'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_all_paths('{}'::jsonb, 'root') $$,
+  $$ values (ARRAY['root']::text[]) $$,
+  'an empty object with a non-empty prefix yields the prefix itself as the only path'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_all_paths(NULL, '') $$,
+  $$ values (ARRAY['']::text[]) $$,
+  'a NULL jsonb value with an empty prefix yields a single empty-string path (current behavior)'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_all_paths(NULL, 'abcd') $$,
+  $$ values (ARRAY['abcd']::text[]) $$,
+  'a NULL jsonb value with a prefix yields the prefix itself as the only path (current behavior)'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_all_paths('"abcde"'::jsonb, 'abcd') $$,
+  $$ values (ARRAY['abcd.abcde']::text[]) $$,
+  'a scalar jsonb value appends the (unquoted) scalar to the prefix'
+);
+select results_eq(
+  $$ select fsm_core.jsonb_all_paths('"abcde"'::jsonb, '') $$,
+  $$ values (ARRAY['abcde']::text[]) $$,
+  'a scalar jsonb value with no prefix is just the (unquoted) scalar'
+);
+
+-- Tier 2: fsm_core.test_jsonb_roundtrip — extract-then-rebuild is lossless for a
+-- simple single-branch nested object (no scalar/object key collisions).
+select results_eq(
+  $$ select reconstructed from fsm_core.test_jsonb_roundtrip(
+       '{"creditCheck": {"CheckingCreditScores": {"CheckingEquiGavin": "CheckingForExistingReport"}}}'::jsonb) $$,
+  $$ values ('{"creditCheck": {"CheckingCreditScores": {"CheckingEquiGavin": "CheckingForExistingReport"}}}'::jsonb) $$,
+  'round-tripping a simple nested object through jsonb_all_paths + build_nested_json_recursive is lossless'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134644_fsm_ltree_lca_helper.sql
+++ b/packages/database-src/supabase/tests/20241218134644_fsm_ltree_lca_helper.sql
@@ -1,0 +1,114 @@
+begin;
+select plan(24);
+
+-- Tier 1: structural
+select has_function('fsm_core', 'remove_hashtag_from_text', ARRAY['text'], 'remove_hashtag_from_text(text) exists');
+select has_function('fsm_core', 'sanitize_text_to_ltree', ARRAY['text'], 'sanitize_text_to_ltree(text) exists');
+select has_function('fsm_core', 'sanitize_text_array_to_ltree_array', ARRAY['text[]'], 'sanitize_text_array_to_ltree_array(text[]) exists');
+select has_function('fsm_core', 'sanitize_text_array_to_ltree_text_array', ARRAY['text[]'], 'sanitize_text_array_to_ltree_text_array(text[]) exists');
+select has_function('fsm_core', 'sql_lca_from_array', ARRAY['ltree[]'], 'sql_lca_from_array(ltree[]) exists');
+select has_function('fsm_core', 'get_proper_ancestors_ltree', ARRAY['ltree', 'ltree'], 'get_proper_ancestors_ltree(ltree, ltree) exists');
+select has_function('fsm_core', 'get_proper_ancestors', ARRAY['text', 'text'], 'get_proper_ancestors(text, text) exists');
+
+-- Tier 2: fsm_core.remove_hashtag_from_text
+-- Current behavior: the function reads its local `sanitized_text` variable before
+-- ever assigning it from the `input_text` parameter, so it always returns NULL
+-- regardless of input. Documented here as a characterization test, not an
+-- endorsement of correctness.
+select results_eq(
+  $$ select fsm_core.remove_hashtag_from_text('hello#world') $$,
+  $$ values (NULL::text) $$,
+  'remove_hashtag_from_text currently always returns NULL (input_text is never read — likely a bug)'
+);
+
+-- Tier 2: fsm_core.sanitize_text_to_ltree
+select results_eq(
+  $$ select fsm_core.sanitize_text_to_ltree('#text') $$,
+  $$ values ('text'::ltree) $$,
+  'a leading hashtag is stripped'
+);
+select results_eq(
+  $$ select fsm_core.sanitize_text_to_ltree('#text ') $$,
+  $$ values ('text_'::ltree) $$,
+  'trailing whitespace becomes a trailing underscore'
+);
+select results_eq(
+  $$ select fsm_core.sanitize_text_to_ltree('text abcd') $$,
+  $$ values ('text_abcd'::ltree) $$,
+  'internal whitespace becomes an underscore'
+);
+select results_eq(
+  $$ select fsm_core.sanitize_text_to_ltree('some#text with spaces()') $$,
+  $$ values ('sometext_with_spaces'::ltree) $$,
+  'hashtags and parentheses are stripped, whitespace becomes underscores'
+);
+select results_eq(
+  $$ select fsm_core.sanitize_text_to_ltree('[root.child.grandchild]') $$,
+  $$ values ('root.child.grandchild'::ltree) $$,
+  'square brackets are stripped, leaving a valid dotted ltree path'
+);
+select results_eq(
+  $$ select fsm_core.sanitize_text_to_ltree(NULL) $$,
+  $$ values (NULL::ltree) $$,
+  'NULL input returns NULL'
+);
+select results_eq(
+  $$ select fsm_core.sanitize_text_to_ltree('###') $$,
+  $$ values (NULL::ltree) $$,
+  'an input that sanitizes to an empty string returns NULL'
+);
+
+-- Tier 2: fsm_core.sanitize_text_array_to_ltree_array / _text_array
+select results_eq(
+  $$ select fsm_core.sanitize_text_array_to_ltree_array(ARRAY['abcd #text', '(machine)', '###']) $$,
+  $$ values (ARRAY['abcd_text', 'machine']::ltree[]) $$,
+  'elements that sanitize to empty are skipped from the ltree[] result'
+);
+select results_eq(
+  $$ select fsm_core.sanitize_text_array_to_ltree_array(NULL) $$,
+  $$ values (ARRAY[]::ltree[]) $$,
+  'NULL input array returns an empty ltree[]'
+);
+select results_eq(
+  $$ select fsm_core.sanitize_text_array_to_ltree_text_array(ARRAY['abcd #text', '(machine)']) $$,
+  $$ values (ARRAY['abcd_text', 'machine']::text[]) $$,
+  'the text[]-returning variant sanitizes the same way, as text'
+);
+
+-- Tier 2: fsm_core.sql_lca_from_array — the custom LCA implementation
+-- (the file notes ltree's own built-in lca() does not work as expected here).
+select results_eq(
+  $$ select fsm_core.sql_lca_from_array(ARRAY['a'::ltree, 'a.b.c'::ltree, 'a.b.c.f'::ltree]) $$,
+  $$ values ('a'::ltree) $$,
+  'when the root itself is one of the inputs, the LCA is the root'
+);
+select results_eq(
+  $$ select fsm_core.sql_lca_from_array(ARRAY['a.b.c.d'::ltree, 'a.b.c.e'::ltree, 'a.b.c.f'::ltree]) $$,
+  $$ values ('a.b.c'::ltree) $$,
+  'the common ancestor of three siblings is their shared parent path'
+);
+select results_eq(
+  $$ select fsm_core.sql_lca_from_array(ARRAY['a.b.c.d'::ltree, 'x.y.z'::ltree]) $$,
+  $$ values (NULL::ltree) $$,
+  'disjoint trees have no common ancestor'
+);
+
+-- Tier 2: fsm_core.get_proper_ancestors_ltree / get_proper_ancestors
+select results_eq(
+  $$ select fsm_core.get_proper_ancestors_ltree('a.b.c.d'::ltree, 'a'::ltree) $$,
+  $$ values (ARRAY['a.b.c', 'a.b']::ltree[]) $$,
+  'walks up from the child, stopping before (excluding) the given ancestor and the ancestor itself'
+);
+select results_eq(
+  $$ select fsm_core.get_proper_ancestors_ltree('a.b.c'::ltree, 'a.b.c'::ltree) $$,
+  $$ values (ARRAY[]::ltree[]) $$,
+  'equal start and stop paths yield no ancestors'
+);
+select results_eq(
+  $$ select fsm_core.get_proper_ancestors('a.b.c.d', 'a') $$,
+  $$ values (ARRAY['a.b.c', 'a.b']::text[]) $$,
+  'the text-typed variant matches the ltree-typed variant'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134645_fsm_dependencies.sql
+++ b/packages/database-src/supabase/tests/20241218134645_fsm_dependencies.sql
@@ -1,0 +1,74 @@
+begin;
+select plan(18);
+
+-- Tier 1: structural
+select has_table('fsm_core', 'fsm_dependencies', 'fsm_core.fsm_dependencies exists');
+select has_column('fsm_core', 'fsm_dependencies', 'parent_fsm_name', 'has parent_fsm_name column');
+select has_column('fsm_core', 'fsm_dependencies', 'parent_fsm_version', 'has parent_fsm_version column');
+select has_column('fsm_core', 'fsm_dependencies', 'child_fsm_name', 'has child_fsm_name column');
+select has_column('fsm_core', 'fsm_dependencies', 'child_fsm_version', 'has child_fsm_version column');
+select col_is_pk('fsm_core', 'fsm_dependencies',
+  ARRAY['parent_fsm_name', 'parent_fsm_version', 'child_fsm_name', 'child_fsm_version'],
+  'composite PK covers all four columns');
+select has_trigger('fsm_core', 'fsm_dependencies', 'enforce_fsm_no_cycles',
+  'enforce_fsm_no_cycles trigger exists');
+select has_function('fsm_core', 'check_fsm_circular_dependency',
+  'fsm_core.check_fsm_circular_dependency() exists');
+select has_function('fsm_core', 'insert_fsm_dependencies',
+  'fsm_core.insert_fsm_dependencies() exists');
+
+-- Tier 2: behavioral — build a small dependency graph A -> B -> D -> E,
+-- then prove the trigger blocks self-loops and cycles, and that the
+-- bulk-insert helper is both cycle-safe and idempotent (ON CONFLICT DO NOTHING).
+select lives_ok(
+  $$ insert into fsm_core.fsm_dependencies values ('A', '1', 'B', '1') $$,
+  'valid edge A(1) -> B(1) inserts cleanly'
+);
+select lives_ok(
+  $$ insert into fsm_core.fsm_dependencies values ('B', '1', 'C', '1') $$,
+  'valid edge B(1) -> C(1) inserts cleanly'
+);
+select throws_ok(
+  $$ insert into fsm_core.fsm_dependencies values ('A', '1', 'A', '1') $$,
+  'P0001',
+  'Circular dependency: FSM (A 1) cannot depend on itself.',
+  'FSM cannot depend on itself: circular dependency error'
+);
+select throws_ok(
+  $$ insert into fsm_core.fsm_dependencies values ('C', '1', 'A', '1') $$,
+  'P0001',
+  'Circular dependency: linking (C 1) -> (A 1) creates an infinite loop.',
+  'closing the loop C(1) -> A(1) raises a circular dependency error'
+);
+select lives_ok(
+  $$ select fsm_core.insert_fsm_dependencies('D', '1',
+       '[{"fsm_name": "E", "fsm_version": "1"}]'::jsonb) $$,
+  'insert_fsm_dependencies helper inserts D(1) -> E(1)'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_dependencies
+     where parent_fsm_name = 'D' and child_fsm_name = 'E' $$,
+  $$ values (1::bigint) $$,
+  'D(1) -> E(1) edge exists exactly once'
+);
+select lives_ok(
+  $$ select fsm_core.insert_fsm_dependencies('D', '1',
+       '[{"fsm_name": "E", "fsm_version": "1"}]'::jsonb) $$,
+  'repeating the same helper call is a no-op (ON CONFLICT DO NOTHING)'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_dependencies
+     where parent_fsm_name = 'D' and child_fsm_name = 'E' $$,
+  $$ values (1::bigint) $$,
+  'D(1) -> E(1) edge is still exactly one row after the repeat call'
+);
+select throws_ok(
+  $$ select fsm_core.insert_fsm_dependencies('E', '1',
+       '[{"fsm_name": "D", "fsm_version": "1"}]'::jsonb) $$,
+  'P0001',
+  'Circular dependency: linking (E 1) -> (D 1) creates an infinite loop.',
+  'closing a cycle through insert_fsm_dependencies still raises via the trigger'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241218134669_async_operation_claim_scheduled_by_async_ops_workerlet.sql
+++ b/packages/database-src/supabase/tests/20241218134669_async_operation_claim_scheduled_by_async_ops_workerlet.sql
@@ -1,0 +1,49 @@
+begin;
+select plan(6);
+
+select has_function('fsm_core', 'claim_scheduled_for_async_operation_workerlet', ARRAY['uuid'],
+  'claim_scheduled_for_async_operation_workerlet(uuid) exists');
+
+delete from fsm_core.async_operation_instance_and_async_operation_workerlet;
+
+select results_eq(
+  $$ select fsm_core.claim_scheduled_for_async_operation_workerlet('11111111-1111-1111-1111-111111111111'::uuid) $$,
+  $$ values (null::jsonb) $$,
+  'nothing scheduled for this workerlet: claim returns null'
+);
+
+insert into fsm_core.async_operation_instance_and_async_operation_workerlet
+  (async_operation_instance_and_async_operation_workerlet_id, async_operation_instance_id,
+   async_operation_workerlet_id, async_operation_name, async_operation_version,
+   async_operation_type, parent_fsm_name, parent_fsm_version, async_operation_language, status, scheduled_at)
+values
+  ('55555555-5555-5555-5555-555555555555'::uuid, '22222222-2222-2222-2222-222222222222'::uuid,
+   '11111111-1111-1111-1111-111111111111'::uuid, 'opY', '1', 'internalAsync', 'fsmY', '1', 'python', 'scheduled', now()),
+  ('66666666-6666-6666-6666-666666666666'::uuid, '77777777-7777-7777-7777-777777777777'::uuid,
+   '99999999-9999-9999-9999-999999999999'::uuid, 'opZ', '1', 'internalAsync', 'fsmZ', '1', 'python', 'scheduled', now());
+
+select results_eq(
+  $$ select (fsm_core.claim_scheduled_for_async_operation_workerlet('11111111-1111-1111-1111-111111111111'::uuid) ->> 'async_operation_instance_id')::uuid $$,
+  $$ values ('22222222-2222-2222-2222-222222222222'::uuid) $$,
+  'claim returns the row scheduled for this specific workerlet'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.async_operation_instance_and_async_operation_workerlet
+     where async_operation_instance_and_async_operation_workerlet_id = '55555555-5555-5555-5555-555555555555'::uuid $$,
+  $$ values (0::bigint) $$,
+  'the claimed row is deleted (atomic claim-and-remove)'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.async_operation_instance_and_async_operation_workerlet
+     where async_operation_instance_and_async_operation_workerlet_id = '66666666-6666-6666-6666-666666666666'::uuid $$,
+  $$ values (1::bigint) $$,
+  'a row scheduled for a different workerlet is left untouched'
+);
+select results_eq(
+  $$ select fsm_core.claim_scheduled_for_async_operation_workerlet('11111111-1111-1111-1111-111111111111'::uuid) $$,
+  $$ values (null::jsonb) $$,
+  'claiming again for the same workerlet returns null (already claimed)'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241221134651_fsm_load_v2.sql
+++ b/packages/database-src/supabase/tests/20241221134651_fsm_load_v2.sql
@@ -1,0 +1,109 @@
+begin;
+select plan(13);
+
+select has_function('fsm_core', 'load_fsm_state_from_json_v2', ARRAY['jsonb', 'text', 'text', 'text'],
+  'load_fsm_state_from_json_v2(jsonb, text, text, text) exists');
+select has_function('fsm_core', 'load_fsm_transition_from_json_v2', ARRAY['jsonb', 'text', 'text', 'text'],
+  'load_fsm_transition_from_json_v2(jsonb, text, text, text) exists');
+
+-- Isolate from any pre-existing rows for this fsm_name/version in the shared
+-- local dev database; the outer rollback restores prior state afterward.
+delete from fsm_core.fsm_transitions where fsm_name = 'testFsm' and fsm_version = 'v9';
+delete from fsm_core.fsm_states where fsm_name = 'testFsm' and fsm_version = 'v9';
+
+-- A small realistic compound FSM: root "light" with two atomic children
+-- "red"/"green", each transitioning to the other on "NEXT". Source/target refs
+-- use the "#"-prefixed convention (matching the real XState-derived JSON) so
+-- fsm_core.sanitize_text_to_ltree strips the "#" down to the plain state id.
+select results_eq(
+  $$ select fsm_core.load_fsm_state_from_json_v2(
+       '{"id":"light","key":"light","type":"compound","order":-1,"states":{
+          "red":{"id":"light.red","key":"red","type":"atomic","order":1,
+            "transitions":[{"source":"#light.red","target":["#light.green"],"eventType":"NEXT","actions":[]}]},
+          "green":{"id":"light.green","key":"green","type":"atomic","order":2,
+            "transitions":[{"source":"#light.green","target":["#light.red"],"eventType":"NEXT","actions":[]}]}
+        }}'::jsonb,
+       NULL, 'testFsm', 'v9') $$,
+  $$ values ('{"ok": true, "fsm_core.fsm_states_count": 3}'::jsonb) $$,
+  'loading the fixture inserts the root plus two nested states (3 total calls)'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_states where fsm_name = 'testFsm' and fsm_version = 'v9' $$,
+  $$ values (3::bigint) $$,
+  'three rows are actually inserted into fsm_states'
+);
+select results_eq(
+  $$ select parent_node, type from fsm_core.fsm_states
+     where fsm_name = 'testFsm' and fsm_version = 'v9' and computed_state_id_ltree = 'light'::ltree $$,
+  $$ values (NULL::text, 'compound'::fsm_core.fsm_state_type) $$,
+  'the root state has no parent_node and the correct type'
+);
+select results_eq(
+  $$ select parent_node, type, computed_state_key_ltree from fsm_core.fsm_states
+     where fsm_name = 'testFsm' and fsm_version = 'v9' and computed_state_id_ltree = 'light.red'::ltree $$,
+  $$ values ('light'::text, 'atomic'::fsm_core.fsm_state_type, 'light.red'::ltree) $$,
+  'the nested "red" state has parent_node=light and the correct computed key path'
+);
+select results_eq(
+  $$ select parent_node, type, computed_state_key_ltree from fsm_core.fsm_states
+     where fsm_name = 'testFsm' and fsm_version = 'v9' and computed_state_id_ltree = 'light.green'::ltree $$,
+  $$ values ('light'::text, 'atomic'::fsm_core.fsm_state_type, 'light.green'::ltree) $$,
+  'the nested "green" state has parent_node=light and the correct computed key path'
+);
+
+-- Transitions can only resolve source/target lookups once the corresponding
+-- fsm_states rows exist (as they now do, from the load above).
+select results_eq(
+  $$ select fsm_core.load_fsm_transition_from_json_v2(
+       '{"id":"light","key":"light","type":"compound","order":-1,"states":{
+          "red":{"id":"light.red","key":"red","type":"atomic","order":1,
+            "transitions":[{"source":"#light.red","target":["#light.green"],"eventType":"NEXT","actions":[]}]},
+          "green":{"id":"light.green","key":"green","type":"atomic","order":2,
+            "transitions":[{"source":"#light.green","target":["#light.red"],"eventType":"NEXT","actions":[]}]}
+        }}'::jsonb,
+       NULL, 'testFsm', 'v9') $$,
+  $$ values ('{"ok": true, "fsm_core.fsm_transitions_count": 3}'::jsonb) $$,
+  'loading transitions recurses through the root plus two nested states (3 total calls)'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_transitions where fsm_name = 'testFsm' and fsm_version = 'v9' $$,
+  $$ values (2::bigint) $$,
+  'only the two leaf states contribute an actual transition row (the root has none)'
+);
+select results_eq(
+  $$ select computed_sanitized_source_ltree, computed_sanitized_target_ltree_array, event_type, computed_transition_domain_lca
+     from fsm_core.fsm_transitions
+     where fsm_name = 'testFsm' and fsm_version = 'v9' and source = '#light.red' $$,
+  $$ values ('light.red'::ltree, ARRAY['light.green'::ltree], 'NEXT'::text, 'light'::text) $$,
+  'the red->green transition resolves source/target ltrees and the LCA domain correctly'
+);
+select results_eq(
+  $$ select computed_sanitized_source_ltree, computed_sanitized_target_ltree_array, event_type, computed_transition_domain_lca
+     from fsm_core.fsm_transitions
+     where fsm_name = 'testFsm' and fsm_version = 'v9' and source = '#light.green' $$,
+  $$ values ('light.green'::ltree, ARRAY['light.red'::ltree], 'NEXT'::text, 'light'::text) $$,
+  'the green->red transition resolves source/target ltrees and the LCA domain correctly'
+);
+
+-- Tier 2: invoke validation in load_fsm_state_from_json_v2 — an invoke item
+-- with fsmType "fsm" must reference an existing (fsm_name, fsm_version) pair
+-- already present in fsm_states, or the whole load is rejected.
+select throws_ok(
+  $$ select fsm_core.load_fsm_state_from_json_v2(
+       '{"id":"invokeTest","key":"invokeTest","type":"atomic","order":-1,
+         "invoke":[{"type":"child","id":"childInst","src":"missingChildFsm","fsmType":"fsm","fsmVersion":"v1"}]}'::jsonb,
+       NULL, 'invokeTestFsm', 'v1') $$,
+  'P0001',
+  'Child FSM not found in fsm_core.fsm_states: missingChildFsm, v1',
+  'an invoke referencing a non-existent child FSM raises'
+);
+select lives_ok(
+  $$ select fsm_core.load_fsm_state_from_json_v2(
+       '{"id":"invokeTest2","key":"invokeTest2","type":"atomic","order":-1,
+         "invoke":[{"type":"child","id":"childInst","src":"testFsm","fsmType":"fsm","fsmVersion":"v9"}]}'::jsonb,
+       NULL, 'invokeTestFsm2', 'v1') $$,
+  'an invoke referencing an existing (fsm_name, fsm_version) pair does not raise'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241221134661_fsm_state_values_v2.sql
+++ b/packages/database-src/supabase/tests/20241221134661_fsm_state_values_v2.sql
@@ -1,0 +1,65 @@
+begin;
+select plan(11);
+
+select has_function('fsm_core', 'fsm_get_initial_state_nodes_v2', ARRAY['text', 'text', 'ltree'],
+  'fsm_get_initial_state_nodes_v2(text, text, ltree) exists');
+select has_function('fsm_core', 'fsm_get_initial_state_nodes_with_ancestors_v2', ARRAY['text', 'text', 'ltree'],
+  'fsm_get_initial_state_nodes_with_ancestors_v2(text, text, ltree) exists');
+select has_function('fsm_core', 'fsm_get_all_state_nodes_v2', ARRAY['text[]', 'text', 'text'],
+  'fsm_get_all_state_nodes_v2(text[], text, text) exists');
+select has_function('fsm_core', 'resolve_state_value_v2', ARRAY['jsonb', 'text', 'text'],
+  'resolve_state_value_v2(jsonb, text, text) exists');
+
+-- Isolate from any pre-existing rows for this fsm_name/version.
+delete from fsm_core.fsm_states where fsm_name = 'sv' and fsm_version = 'tv1';
+
+-- Fixture: compound root -> parallel p1 -> two atomic children c1/c2.
+insert into fsm_core.fsm_states
+  (state_id_with_fsm_name_and_fsm_version, computed_state_id_ltree, computed_state_key_ltree,
+   id, key, parent_node, type, fsm_order, initial, states, fsm_name, fsm_version)
+values
+  ('sv.tv1.root', 'root', 'root', 'root', 'root', NULL, 'compound', 1,
+   '{"target": ["#root.p1"], "source": "#root"}'::jsonb, NULL, 'sv', 'tv1'),
+  ('sv.tv1.root.p1', 'root.p1', 'root.p1', 'root.p1', 'p1', 'root', 'parallel', 2,
+   NULL, '{"c1": {"id": "root.p1.c1", "key": "c1"}, "c2": {"id": "root.p1.c2", "key": "c2"}}'::jsonb, 'sv', 'tv1'),
+  ('sv.tv1.root.p1.c1', 'root.p1.c1', 'root.p1.c1', 'root.p1.c1', 'c1', 'root.p1', 'atomic', 3, NULL, NULL, 'sv', 'tv1'),
+  ('sv.tv1.root.p1.c2', 'root.p1.c2', 'root.p1.c2', 'root.p1.c2', 'c2', 'root.p1', 'atomic', 4, NULL, NULL, 'sv', 'tv1');
+
+select results_eq(
+  $$ select fsm_core.fsm_get_initial_state_nodes_v2('sv', 'tv1', 'root'::ltree) $$,
+  $$ values (ARRAY['root', 'root.p1', 'root.p1.c1', 'root.p1.c2']::text[]) $$,
+  'drills through a compound''s initial target into a parallel''s children, including the start node itself'
+);
+select results_eq(
+  $$ select fsm_core.fsm_get_initial_state_nodes_v2('sv', 'tv1', 'root.p1'::ltree) $$,
+  $$ values (ARRAY['root.p1', 'root.p1.c1', 'root.p1.c2']::text[]) $$,
+  'starting directly at the parallel node yields itself plus both children'
+);
+select results_eq(
+  $$ select fsm_core.fsm_get_initial_state_nodes_with_ancestors_v2('sv', 'tv1', 'root'::ltree) $$,
+  $$ values (ARRAY['root', 'root.p1', 'root.p1.c1', 'root.p1.c2']::text[]) $$,
+  'no extra ancestors are added when the initial nodes already sit directly under the start node'
+);
+select results_eq(
+  $$ select fsm_core.fsm_get_all_state_nodes_v2(ARRAY['root'], 'sv', 'tv1') $$,
+  $$ values (ARRAY['root', 'root.p1', 'root.p1.c1', 'root.p1.c2']::text[]) $$,
+  'a lone compound root path expands to its full initial-state subtree'
+);
+select results_eq(
+  $$ select fsm_core.fsm_get_all_state_nodes_v2(ARRAY['root', 'root.p1.c1'], 'sv', 'tv1') $$,
+  $$ values (ARRAY['root', 'root.p1', 'root.p1.c1', 'root.p1.c2', 'root.p1.c1']::text[]) $$,
+  'an atomic path already covered by the compound expansion is still appended again (current behavior: not deduplicated across branches)'
+);
+select results_eq(
+  $$ select fsm_core.resolve_state_value_v2('{}'::jsonb, 'sv', 'tv1') $$,
+  $$ values ('{"json": {"root": {"p1": "c2"}}, "all_nodes": ["root", "root.p1", "root.p1.c1", "root.p1.c2"]}'::jsonb) $$,
+  'resolving an empty state value against the root falls back to the full initial-state subtree'
+);
+select results_eq(
+  $$ select fsm_core.resolve_state_value_v2('{"p1": "c1"}'::jsonb, 'sv', 'tv1') $$,
+  $$ values ('{"json": {"root": {"p1": "c1"}}, "all_nodes": ["root.p1.c1", "root.p1.c2", "root.p1.c1"]}'::jsonb) $$,
+  'resolving an explicit parallel-branch selection preserves that selection in the rebuilt JSON'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241222134632_fsm_exit_actions_v2.sql
+++ b/packages/database-src/supabase/tests/20241222134632_fsm_exit_actions_v2.sql
@@ -1,0 +1,82 @@
+begin;
+select plan(10);
+
+select has_function('fsm_core', 'get_exit_actions_v2', ARRAY['text[]', 'text', 'text'],
+  'get_exit_actions_v2(text[], text, text) exists');
+select has_function('fsm_core', 'compute_child_exit_set_v2', ARRAY['ltree', 'ltree[]'],
+  'compute_child_exit_set_v2(ltree, ltree[]) exists');
+select has_function('fsm_core', 'compute_full_exit_set_v2', ARRAY['fsm_core.fsm_transitions', 'text[]'],
+  'compute_full_exit_set_v2(fsm_transitions, text[]) exists');
+select has_function('fsm_core', 'compute_exit_actions_v2', ARRAY['fsm_core.fsm_transitions', 'text[]', 'text', 'text'],
+  'compute_exit_actions_v2(fsm_transitions, text[], text, text) exists');
+
+-- Isolate from any pre-existing rows for this fsm_name/version.
+delete from fsm_core.fsm_transitions where fsm_name = 'ea' and fsm_version = 'v1';
+delete from fsm_core.fsm_states where fsm_name = 'ea' and fsm_version = 'v1';
+
+-- Fixture: root "m" (exit action) with atomic children "m.a" (exit + invoke
+-- actions) and "m.b" (no actions).
+insert into fsm_core.fsm_states
+  (state_id_with_fsm_name_and_fsm_version, computed_state_id_ltree, computed_state_key_ltree,
+   id, key, parent_node, type, fsm_order, exit, invoke, fsm_name, fsm_version)
+values
+  ('ea.v1.m', 'm', 'm', 'm', 'm', NULL, 'compound', 1, '[{"type": "logExitM"}]'::jsonb, '[]'::jsonb, 'ea', 'v1'),
+  ('ea.v1.m.a', 'm.a', 'm.a', 'm.a', 'a', 'm', 'atomic', 2, '[{"type": "cleanupA"}]'::jsonb, '[{"type": "stopInvokeA"}]'::jsonb, 'ea', 'v1'),
+  ('ea.v1.m.b', 'm.b', 'm.b', 'm.b', 'b', 'm', 'atomic', 3, '[]'::jsonb, '[]'::jsonb, 'ea', 'v1');
+
+-- Two transitions: a reentering self-transition on the root "m" (domain == m),
+-- and a non-reentering transition from "m.a" whose domain is also "m".
+insert into fsm_core.fsm_transitions
+  (source, computed_sanitized_source_ltree, target, computed_sanitized_target_ltree_array,
+   event_type, computed_transition_domain_lca, reenter, fsm_name, fsm_version)
+values
+  ('#m', 'm', ARRAY['#m']::text[], ARRAY['m'::ltree], 'SELF', 'm', true, 'ea', 'v1'),
+  ('#m.a', 'm.a', ARRAY['#m.b']::text[], ARRAY['m.b'::ltree], 'LEAVE_A', 'm', false, 'ea', 'v1');
+
+select results_eq(
+  $$ select fsm_core.get_exit_actions_v2(ARRAY['m', 'm.a'], 'ea', 'v1') $$,
+  $$ values ('{"actions": [
+       {"type": "cleanupA", "fsm_order": 2, "action_type": "exit"},
+       {"type": "stopInvokeA", "fsm_order": 2, "action_type": "invoke"},
+       {"type": "logExitM", "fsm_order": 1, "action_type": "exit"}
+     ]}'::jsonb) $$,
+  'collects exit and invoke actions from all matching states, tagged and ordered by fsm_order DESC'
+);
+select results_eq(
+  $$ select fsm_core.compute_child_exit_set_v2('m'::ltree, ARRAY['m'::ltree, 'm.a'::ltree, 'm.b'::ltree, 'other'::ltree]) $$,
+  $$ values (ARRAY['m', 'm.a', 'm.b']::text[]) $$,
+  'keeps only nodes that are the domain itself or its descendants'
+);
+select results_eq(
+  $$ select fsm_core.compute_full_exit_set_v2(
+       (select t from fsm_core.fsm_transitions t where event_type = 'SELF' and fsm_name = 'ea' and fsm_version = 'v1'),
+       ARRAY['m.a', 'm.b']) $$,
+  $$ values (ARRAY['m', 'm.a', 'm.b']::text[]) $$,
+  'a reentering self-transition (source == domain) adds the domain itself to the exit set'
+);
+select results_eq(
+  $$ select fsm_core.compute_full_exit_set_v2(
+       (select t from fsm_core.fsm_transitions t where event_type = 'LEAVE_A' and fsm_name = 'ea' and fsm_version = 'v1'),
+       ARRAY['m.a', 'm.b']) $$,
+  $$ values (ARRAY['m.a', 'm.b']::text[]) $$,
+  'a non-reentering transition does not add the source itself, only its descendants'
+);
+select results_eq(
+  $$ select fsm_core.compute_exit_actions_v2(
+       (select t from fsm_core.fsm_transitions t where event_type = 'SELF' and fsm_name = 'ea' and fsm_version = 'v1'),
+       ARRAY['m.a', 'm.b'], 'ea', 'v1') $$,
+  $$ values ('{"exit_nodes": ["m", "m.a", "m.b"], "exit_actions": [
+       {"type": "cleanupA", "fsm_order": 2, "action_type": "exit"},
+       {"type": "stopInvokeA", "fsm_order": 2, "action_type": "invoke"},
+       {"type": "logExitM", "fsm_order": 1, "action_type": "exit"}
+     ]}'::jsonb) $$,
+  'combines the full exit set with its resolved exit/invoke actions'
+);
+select results_eq(
+  $$ select fsm_core.compute_exit_actions_v2(NULL, ARRAY['m.a', 'm.b'], 'ea', 'v1') $$,
+  $$ values ('{"exit_nodes": [], "exit_actions": []}'::jsonb) $$,
+  'a NULL transition record (no matching transition) yields empty exit nodes and actions'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241222134642_fsm_entry_actions_v2.sql
+++ b/packages/database-src/supabase/tests/20241222134642_fsm_entry_actions_v2.sql
@@ -1,0 +1,117 @@
+begin;
+select plan(18);
+
+-- Tier 1: structural
+select has_function('fsm_core', 'get_initial_actions_v2', ARRAY['text[]', 'text', 'text'],
+  'get_initial_actions_v2(text[], text, text) exists');
+select has_function('fsm_core', 'get_entry_actions_v2', ARRAY['text[]', 'text', 'text'],
+  'get_entry_actions_v2(text[], text, text) exists');
+select has_type('fsm_core', 'descendant_states_result_v2', 'descendant_states_result_v2 type exists');
+select has_column('fsm_core', 'descendant_states_result_v2', 'descendant_states_to_enter', 'has descendant_states_to_enter field');
+select has_column('fsm_core', 'descendant_states_result_v2', 'descendant_states_for_default_entry', 'has descendant_states_for_default_entry field');
+select has_function('fsm_core', 'get_descendant_states_for_entry_v2', ARRAY['text', 'text', 'text'],
+  'get_descendant_states_for_entry_v2(text, text, text) exists');
+select has_type('fsm_core', 'ancestor_states_result_v2', 'ancestor_states_result_v2 type exists');
+select has_column('fsm_core', 'ancestor_states_result_v2', 'ancestor_states_to_enter', 'has ancestor_states_to_enter field');
+select has_column('fsm_core', 'ancestor_states_result_v2', 'ancestor_states_for_default_entry', 'has ancestor_states_for_default_entry field');
+select has_function('fsm_core', 'get_ancestor_states_for_entry_v2', ARRAY['text[]', 'text', 'text', 'text'],
+  'get_ancestor_states_for_entry_v2(text[], text, text, text) exists');
+select has_function('fsm_core', 'compute_entry_actions_v2', ARRAY['fsm_core.fsm_transitions', 'text', 'text', 'boolean'],
+  'compute_entry_actions_v2(fsm_transitions, text, text, boolean) exists');
+
+-- Isolate from any pre-existing rows for this fsm_name/version.
+delete from fsm_core.fsm_transitions where fsm_name = 'enact' and fsm_version = 'v1';
+delete from fsm_core.fsm_states where fsm_name = 'enact' and fsm_version = 'v1';
+
+-- Fixture: compound root "r" (initial -> c1) with a nested compound child
+-- "r.c1" (initial -> its own atomic child "r.c1.a"), plus a sibling atomic "r.c2".
+insert into fsm_core.fsm_states
+  (state_id_with_fsm_name_and_fsm_version, computed_state_id_ltree, computed_state_key_ltree,
+   id, key, parent_node, type, fsm_order, initial, entry, fsm_name, fsm_version)
+values
+  ('enact.v1.r', 'r', 'r', 'r', 'r', NULL, 'compound', 1,
+   '{"target": ["#r.c1"], "source": "#r"}'::jsonb, '[{"type": "enterR"}]'::jsonb, 'enact', 'v1'),
+  ('enact.v1.r.c1', 'r.c1', 'r.c1', 'r.c1', 'c1', 'r', 'compound', 2,
+   '{"target": ["#r.c1.a"], "source": "#r.c1"}'::jsonb, '[{"type": "enterC1"}]'::jsonb, 'enact', 'v1'),
+  ('enact.v1.r.c1.a', 'r.c1.a', 'r.c1.a', 'r.c1.a', 'a', 'r.c1', 'atomic', 3,
+   NULL, '[{"type": "enterA"}]'::jsonb, 'enact', 'v1'),
+  ('enact.v1.r.c2', 'r.c2', 'r.c2', 'r.c2', 'c2', 'r', 'atomic', 4,
+   NULL, '[{"type": "enterC2"}]'::jsonb, 'enact', 'v1');
+
+insert into fsm_core.fsm_transitions
+  (source, computed_sanitized_source_ltree, target, computed_sanitized_target_ltree_array,
+   event_type, computed_transition_domain_lca, reenter, fsm_name, fsm_version)
+values
+  ('#r', 'r', ARRAY['#r.c2']::text[], ARRAY['r.c2'::ltree], 'GO_C2', 'r', false, 'enact', 'v1'),
+  ('#r', 'r', ARRAY['#r.c1']::text[], ARRAY['r.c1'::ltree], 'GO_C1', 'r', false, 'enact', 'v1');
+
+select results_eq(
+  $$ select fsm_core.get_entry_actions_v2(ARRAY['r', 'r.c2'], 'enact', 'v1') $$,
+  $$ values ('[
+       {"type": "enterC2", "fsm_order": 4, "action_type": "entry", "parentFsmName": "enact", "parentFsmVersion": "v1"},
+       {"type": "enterR", "fsm_order": 1, "action_type": "entry", "parentFsmName": "enact", "parentFsmVersion": "v1"}
+     ]'::jsonb) $$,
+  'collects entry actions from matching states, tagged with fsm_order/parent FSM and ordered DESC'
+);
+select results_eq(
+  $$ select fsm_core.get_initial_actions_v2(ARRAY['r'], 'enact', 'v1') $$,
+  $$ values ('[]'::jsonb) $$,
+  'a state whose "initial" has no actions array contributes nothing'
+);
+select results_eq(
+  $$ select fsm_core.get_descendant_states_for_entry_v2('r.c1', 'enact', 'v1') $$,
+  $$ values (ROW(ARRAY['r.c1.a'], ARRAY['r.c1.a'])::fsm_core.descendant_states_result_v2) $$,
+  'a compound state''s descendants resolve through its initial target down to the atomic leaf'
+);
+select results_eq(
+  $$ select fsm_core.compute_entry_actions_v2(
+       (select t from fsm_core.fsm_transitions t where event_type = 'GO_C2' and fsm_name = 'enact' and fsm_version = 'v1'),
+       'enact', 'v1', false) $$,
+  $$ values ('{
+       "common_states": ["r.c2"],
+       "states_to_enter": ["r.c2"],
+       "states_for_default_entry": ["r.c2"],
+       "entry_actions_for_states_to_enter": [{"type": "enterC2", "fsm_order": 4, "action_type": "entry", "parentFsmName": "enact", "parentFsmVersion": "v1"}],
+       "initial_actions_for_common_states": []
+     }'::jsonb) $$,
+  'a transition straight to an atomic sibling only enters that one state'
+);
+select results_eq(
+  $$ select fsm_core.compute_entry_actions_v2(
+       (select t from fsm_core.fsm_transitions t where event_type = 'GO_C1' and fsm_name = 'enact' and fsm_version = 'v1'),
+       'enact', 'v1', false) $$,
+  $$ values ('{
+       "common_states": ["r.c1", "r.c1.a"],
+       "states_to_enter": ["r.c1", "r.c1.a"],
+       "states_for_default_entry": ["r.c1", "r.c1.a"],
+       "entry_actions_for_states_to_enter": [
+         {"type": "enterA", "fsm_order": 3, "action_type": "entry", "parentFsmName": "enact", "parentFsmVersion": "v1"},
+         {"type": "enterC1", "fsm_order": 2, "action_type": "entry", "parentFsmName": "enact", "parentFsmVersion": "v1"}
+       ],
+       "initial_actions_for_common_states": []
+     }'::jsonb) $$,
+  'a transition to a compound target also enters its initial descendant chain'
+);
+select results_eq(
+  $$ select fsm_core.compute_entry_actions_v2(NULL, 'enact', 'v1', true) $$,
+  $$ values ('{
+       "common_states": [],
+       "states_to_enter": ["r", "r.c1", "r.c1.a"],
+       "states_for_default_entry": [],
+       "entry_actions_for_states_to_enter": [
+         {"type": "enterA", "fsm_order": 3, "action_type": "entry", "parentFsmName": "enact", "parentFsmVersion": "v1"},
+         {"type": "enterC1", "fsm_order": 2, "action_type": "entry", "parentFsmName": "enact", "parentFsmVersion": "v1"},
+         {"type": "enterR", "fsm_order": 1, "action_type": "entry", "parentFsmName": "enact", "parentFsmVersion": "v1"}
+       ],
+       "initial_actions_for_common_states": []
+     }'::jsonb) $$,
+  'an initial transition (no transition record needed) enters the whole default initial-state chain from the root'
+);
+select results_eq(
+  $$ select fsm_core.compute_entry_actions_v2(NULL, 'enact', 'v1', false) $$,
+  $$ values ('{"common_states": [], "states_to_enter": [], "states_for_default_entry": [], "entry_actions_for_states_to_enter": [], "initial_actions_for_common_states": []}'::jsonb) $$,
+  'a NULL transition record on a non-initial transition yields an all-empty result'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241222134742_fsm_microstep_v2.sql
+++ b/packages/database-src/supabase/tests/20241222134742_fsm_microstep_v2.sql
@@ -1,0 +1,62 @@
+begin;
+select plan(3);
+
+select has_function('fsm_core', 'microstep_v2',
+  ARRAY['fsm_core.fsm_transitions', 'text', 'text[]', 'text', 'text'],
+  'microstep_v2(fsm_transitions, text, text[], text, text) exists');
+
+-- Isolate from any pre-existing rows for this fsm_name/version.
+delete from fsm_core.fsm_transitions where fsm_name = 'ms' and fsm_version = 'v1';
+delete from fsm_core.fsm_states where fsm_name = 'ms' and fsm_version = 'v1';
+
+-- Fixture: compound root "r" (initial -> a) with atomic siblings "r.a"/"r.b",
+-- each carrying its own entry/exit actions, plus a transition a -> b.
+insert into fsm_core.fsm_states
+  (state_id_with_fsm_name_and_fsm_version, computed_state_id_ltree, computed_state_key_ltree,
+   id, key, parent_node, type, fsm_order, initial, entry, exit, fsm_name, fsm_version)
+values
+  ('ms.v1.r', 'r', 'r', 'r', 'r', NULL, 'compound', 1,
+   '{"target": ["#r.a"], "source": "#r"}'::jsonb, '[{"type": "enterR"}]'::jsonb, '[{"type": "exitR"}]'::jsonb, 'ms', 'v1'),
+  ('ms.v1.r.a', 'r.a', 'r.a', 'r.a', 'a', 'r', 'atomic', 2,
+   NULL, '[{"type": "enterA"}]'::jsonb, '[{"type": "exitA"}]'::jsonb, 'ms', 'v1'),
+  ('ms.v1.r.b', 'r.b', 'r.b', 'r.b', 'b', 'r', 'atomic', 3,
+   NULL, '[{"type": "enterB"}]'::jsonb, '[{"type": "exitB"}]'::jsonb, 'ms', 'v1');
+
+insert into fsm_core.fsm_transitions
+  (source, computed_sanitized_source_ltree, target, computed_sanitized_target_ltree_array,
+   event_type, actions, computed_transition_domain_lca, reenter, fsm_name, fsm_version)
+values
+  ('#r.a', 'r.a', ARRAY['#r.b']::text[], ARRAY['r.b'::ltree], 'NEXT', '[{"type": "doNext"}]'::jsonb, 'r', false, 'ms', 'v1');
+
+select results_eq(
+  $$ select fsm_core.microstep_v2(
+       (select t from fsm_core.fsm_transitions t where event_type = 'NEXT' and fsm_name = 'ms' and fsm_version = 'v1'),
+       'NEXT', ARRAY['r', 'r.a'], 'ms', 'v1') $$,
+  $$ values ('{
+       "exit_actions": [{"type": "exitA", "fsm_order": 2, "action_type": "exit"}, {"type": "exitR", "fsm_order": 1, "action_type": "exit"}],
+       "entry_actions": [{"type": "enterB", "fsm_order": 3, "action_type": "entry", "parentFsmName": "ms", "parentFsmVersion": "v1"}],
+       "initial_actions": [],
+       "transition_actions": [{"type": "doNext"}],
+       "updated_state_value": {"r": "b"},
+       "updated_state_value_node_set": ["r.b"]
+     }'::jsonb) $$,
+  'a normal transition exits the old node set, enters the target, and rebuilds the state value'
+);
+select results_eq(
+  $$ select fsm_core.microstep_v2(NULL, 'initialTransition_event', ARRAY[]::text[], 'ms', 'v1') $$,
+  $$ values ('{
+       "exit_actions": [],
+       "entry_actions": [
+         {"type": "enterA", "fsm_order": 2, "action_type": "entry", "parentFsmName": "ms", "parentFsmVersion": "v1"},
+         {"type": "enterR", "fsm_order": 1, "action_type": "entry", "parentFsmName": "ms", "parentFsmVersion": "v1"}
+       ],
+       "initial_actions": [],
+       "transition_actions": null,
+       "updated_state_value": {"r": "a"},
+       "updated_state_value_node_set": ["r", "r.a"]
+     }'::jsonb) $$,
+  'the initialTransition_event enters the machine''s default initial-state chain with no exits'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20241222134842_fsm_macrostep_v2.sql
+++ b/packages/database-src/supabase/tests/20241222134842_fsm_macrostep_v2.sql
@@ -1,0 +1,106 @@
+begin;
+select plan(11);
+
+select has_function('fsm_core', 'select_transitions_with_guard_eval_v2', ARRAY['fsm_core.fsm_transitions[]'],
+  'select_transitions_with_guard_eval_v2(fsm_transitions[]) exists');
+select has_function('fsm_core', 'select_all_transitions_v2', ARRAY['text', 'text[]', 'text', 'text'],
+  'select_all_transitions_v2(text, text[], text, text) exists');
+select has_function('fsm_core', 'macrostep_v2', ARRAY['text', 'text[]', 'text', 'text'],
+  'macrostep_v2(text, text[], text, text) exists');
+select has_function('fsm_core', 'fsm_worker_v2', ARRAY['text', 'jsonb', 'text', 'text'],
+  'fsm_worker_v2(text, jsonb, text, text) exists');
+
+-- Isolate from any pre-existing rows for this fsm_name/version.
+delete from fsm_core.fsm_transitions where fsm_name = 'ms' and fsm_version = 'v1';
+delete from fsm_core.fsm_states where fsm_name = 'ms' and fsm_version = 'v1';
+
+-- Fixture: same compound root "r" (initial -> a) with atomic siblings
+-- "r.a"/"r.b" used in the microstep tests, plus:
+--   NEXT       - a single unambiguous transition
+--   GUARDED    - two candidates for the same event/source, disambiguated by cond.value
+--   AMBIGUOUS  - two candidates that both pass guard evaluation (unresolved conflict)
+insert into fsm_core.fsm_states
+  (state_id_with_fsm_name_and_fsm_version, computed_state_id_ltree, computed_state_key_ltree,
+   id, key, parent_node, type, fsm_order, initial, entry, exit, fsm_name, fsm_version)
+values
+  ('ms.v1.r', 'r', 'r', 'r', 'r', NULL, 'compound', 1,
+   '{"target": ["#r.a"], "source": "#r"}'::jsonb, '[{"type": "enterR"}]'::jsonb, '[{"type": "exitR"}]'::jsonb, 'ms', 'v1'),
+  ('ms.v1.r.a', 'r.a', 'r.a', 'r.a', 'a', 'r', 'atomic', 2,
+   NULL, '[{"type": "enterA"}]'::jsonb, '[{"type": "exitA"}]'::jsonb, 'ms', 'v1'),
+  ('ms.v1.r.b', 'r.b', 'r.b', 'r.b', 'b', 'r', 'atomic', 3,
+   NULL, '[{"type": "enterB"}]'::jsonb, '[{"type": "exitB"}]'::jsonb, 'ms', 'v1');
+
+insert into fsm_core.fsm_transitions
+  (source, computed_sanitized_source_ltree, target, computed_sanitized_target_ltree_array,
+   event_type, actions, cond, computed_transition_domain_lca, reenter, fsm_name, fsm_version)
+values
+  ('#r.a', 'r.a', ARRAY['#r.b']::text[], ARRAY['r.b'::ltree], 'NEXT', '[{"type": "doNext"}]'::jsonb, NULL, 'r', false, 'ms', 'v1'),
+  ('#r.a', 'r.a', ARRAY['#r.b']::text[], ARRAY['r.b'::ltree], 'GUARDED', '[{"type": "doGuardedTrue"}]'::jsonb, '{"value": true}'::jsonb, 'r', false, 'ms', 'v1'),
+  ('#r.a', 'r.a', ARRAY['#r.b']::text[], ARRAY['r.b'::ltree], 'GUARDED', '[{"type": "doGuardedFalse"}]'::jsonb, '{"value": false}'::jsonb, 'r', false, 'ms', 'v1'),
+  ('#r.a', 'r.a', ARRAY['#r.b']::text[], ARRAY['r.b'::ltree], 'AMBIGUOUS', '[{"type": "a1"}]'::jsonb, NULL, 'r', false, 'ms', 'v1'),
+  ('#r.a', 'r.a', ARRAY['#r.b']::text[], ARRAY['r.b'::ltree], 'AMBIGUOUS', '[{"type": "a2"}]'::jsonb, NULL, 'r', false, 'ms', 'v1');
+
+select results_eq(
+  $$ select jsonb_array_length(fsm_core.select_all_transitions_v2('NEXT', ARRAY['r.a'], 'ms', 'v1')) $$,
+  $$ values (1) $$,
+  'select_all_transitions_v2 finds the single matching transition by event/source'
+);
+select results_eq(
+  $$ select fsm_core.select_all_transitions_v2('MISSING', ARRAY['r.a'], 'ms', 'v1') $$,
+  $$ values ('[]'::jsonb) $$,
+  'select_all_transitions_v2 returns an empty array when nothing matches'
+);
+select results_eq(
+  $$ select fsm_core.macrostep_v2('NEXT', ARRAY['r', 'r.a'], 'ms', 'v1') $$,
+  $$ values ('{
+       "exit_actions": [{"type": "exitA", "fsm_order": 2, "action_type": "exit"}, {"type": "exitR", "fsm_order": 1, "action_type": "exit"}],
+       "entry_actions": [{"type": "enterB", "fsm_order": 3, "action_type": "entry", "parentFsmName": "ms", "parentFsmVersion": "v1"}],
+       "initial_actions": [],
+       "transition_actions": [{"type": "doNext"}],
+       "updated_state_value": {"r": "b"},
+       "updated_state_value_node_set": ["r.b"]
+     }'::jsonb) $$,
+  'a single unambiguous transition runs straight through to microstep_v2'
+);
+select results_eq(
+  $$ select fsm_core.macrostep_v2('GUARDED', ARRAY['r', 'r.a'], 'ms', 'v1') $$,
+  $$ values ('{
+       "exit_actions": [{"type": "exitA", "fsm_order": 2, "action_type": "exit"}, {"type": "exitR", "fsm_order": 1, "action_type": "exit"}],
+       "entry_actions": [{"type": "enterB", "fsm_order": 3, "action_type": "entry", "parentFsmName": "ms", "parentFsmVersion": "v1"}],
+       "initial_actions": [],
+       "transition_actions": [{"type": "doGuardedTrue"}],
+       "updated_state_value": {"r": "b"},
+       "updated_state_value_node_set": ["r.b"]
+     }'::jsonb) $$,
+  'guard evaluation narrows two same-event candidates down to the one with cond.value = true'
+);
+select throws_ok(
+  $$ select fsm_core.macrostep_v2('MISSING', ARRAY['r', 'r.a'], 'ms', 'v1') $$,
+  'P0001',
+  'No valid transitions found for event_name=MISSING, fsm_name=ms, fsm_version=v1',
+  'an event with no matching transition raises'
+);
+select throws_ok(
+  $$ select fsm_core.macrostep_v2('AMBIGUOUS', ARRAY['r', 'r.a'], 'ms', 'v1') $$,
+  'P0001',
+  'Multiple valid transitions found after guard evaluation for event_name=AMBIGUOUS, fsm_name=ms, fsm_version=v1',
+  'two candidates that both pass guard evaluation raise an unresolved-conflict error'
+);
+select results_eq(
+  $$ select fsm_core.fsm_worker_v2('initialTransition_event', '{}'::jsonb, 'ms', 'v1') $$,
+  $$ values ('{
+       "exit_actions": [],
+       "entry_actions": [
+         {"type": "enterA", "fsm_order": 2, "action_type": "entry", "parentFsmName": "ms", "parentFsmVersion": "v1"},
+         {"type": "enterR", "fsm_order": 1, "action_type": "entry", "parentFsmName": "ms", "parentFsmVersion": "v1"}
+       ],
+       "initial_actions": [],
+       "transition_actions": null,
+       "updated_state_value": {"r": "a"},
+       "updated_state_value_node_set": ["r", "r.a"]
+     }'::jsonb) $$,
+  'fsm_worker_v2 resolves the current state value and drives the initial transition end to end'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250118124637_fsm_workerlet.sql
+++ b/packages/database-src/supabase/tests/20250118124637_fsm_workerlet.sql
@@ -1,0 +1,14 @@
+begin;
+select plan(8);
+
+select has_table('fsm_core', 'fsm_workerlet', 'fsm_core.fsm_workerlet exists');
+select col_is_pk('fsm_core', 'fsm_workerlet', 'fsm_workerlet_id', 'fsm_workerlet_id is the primary key');
+select has_column('fsm_core', 'fsm_workerlet', 'fsm_workerlet_pid', 'has fsm_workerlet_pid column');
+select col_type_is('fsm_core', 'fsm_workerlet', 'fsm_modules', 'jsonb', 'fsm_modules is jsonb');
+select has_column('fsm_core', 'fsm_workerlet', 'max_concurrency', 'has max_concurrency column');
+select has_column('fsm_core', 'fsm_workerlet', 'active_workers', 'has active_workers column');
+select has_column('fsm_core', 'fsm_workerlet', 'last_heartbeat', 'has last_heartbeat column');
+select has_column('fsm_core', 'fsm_workerlet', 'registered_at', 'has registered_at column');
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250118124638_fsm_instance_and_fsm_workerlet.sql
+++ b/packages/database-src/supabase/tests/20250118124638_fsm_instance_and_fsm_workerlet.sql
@@ -1,0 +1,21 @@
+begin;
+select plan(12);
+
+select has_table('fsm_core', 'fsm_instance_and_fsm_workerlet', 'fsm_core.fsm_instance_and_fsm_workerlet exists');
+select col_is_pk('fsm_core', 'fsm_instance_and_fsm_workerlet', 'fsm_instance_and_fsm_workerlet_id',
+  'the surrogate id is the primary key');
+select has_column('fsm_core', 'fsm_instance_and_fsm_workerlet', 'fsm_instance_id', 'has fsm_instance_id column');
+select has_column('fsm_core', 'fsm_instance_and_fsm_workerlet', 'fsm_workerlet_id', 'has fsm_workerlet_id column');
+select has_column('fsm_core', 'fsm_instance_and_fsm_workerlet', 'fsm_name', 'has fsm_name column');
+select has_column('fsm_core', 'fsm_instance_and_fsm_workerlet', 'fsm_version', 'has fsm_version column');
+select has_column('fsm_core', 'fsm_instance_and_fsm_workerlet', 'dispatch_type', 'has dispatch_type column');
+select has_column('fsm_core', 'fsm_instance_and_fsm_workerlet', 'status', 'has status column');
+select has_column('fsm_core', 'fsm_instance_and_fsm_workerlet', 'created_at', 'has created_at column');
+select has_column('fsm_core', 'fsm_instance_and_fsm_workerlet', 'scheduled_at', 'has scheduled_at column');
+select has_index('fsm_core', 'fsm_instance_and_fsm_workerlet', 'idx_fsm_instance_and_fsm_workerlet_pending',
+  'partial index on pending rows exists');
+select has_index('fsm_core', 'fsm_instance_and_fsm_workerlet', 'idx_fsm_instance_and_fsm_workerlet_scheduled',
+  'partial index on scheduled rows exists');
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250118124738_check_registry_for_async_actors_for_fsm_worklet.sql
+++ b/packages/database-src/supabase/tests/20250118124738_check_registry_for_async_actors_for_fsm_worklet.sql
@@ -1,0 +1,27 @@
+begin;
+select plan(3);
+
+select has_function('fsm_core', 'check_registry_for_async_actors', ARRAY['jsonb', 'text', 'text'],
+  'check_registry_for_async_actors(jsonb, text, text) exists');
+
+delete from fsm_core.async_operation_meta where parent_fsm_name = 'crFsm' and parent_fsm_version = 'v1';
+
+insert into fsm_core.async_operation_meta
+  (async_operation_name, async_operation_type, async_operation_version, parent_fsm_name, parent_fsm_version, async_operation_language, updated_by_pid)
+values
+  ('opA', 'internalAsync', '1', 'crFsm', 'v1', 'python', 'pid1');
+
+select results_eq(
+  $$ select fsm_core.check_registry_for_async_actors('[{"src": "opA", "fsmVersion": "1"}]'::jsonb, 'crFsm', 'v1') $$,
+  $$ values ('{"fsm_name": "crFsm", "fsm_version": "v1", "missing_actors": [], "all_registered": true}'::jsonb) $$,
+  'a registered async actor reports all_registered=true with no missing actors'
+);
+select results_eq(
+  $$ select fsm_core.check_registry_for_async_actors(
+       '[{"src": "opA", "fsmVersion": "1"}, {"src": "opMissing", "fsmVersion": "9"}]'::jsonb, 'crFsm', 'v1') $$,
+  $$ values ('{"fsm_name": "crFsm", "fsm_version": "v1", "missing_actors": [{"src": "opMissing", "fsmVersion": "9"}], "all_registered": false}'::jsonb) $$,
+  'an unregistered async actor is reported in missing_actors and flips all_registered to false'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250118124838_check_registry_and_working_for_async_actors_for_fsm_instance_and_worklet.sql
+++ b/packages/database-src/supabase/tests/20250118124838_check_registry_and_working_for_async_actors_for_fsm_instance_and_worklet.sql
@@ -1,0 +1,31 @@
+begin;
+select plan(3);
+
+select has_function('fsm_core', 'check_registry_and_working_for_async_actors_for_fsm_instance_and_worklet',
+  ARRAY['jsonb', 'text', 'text'],
+  'check_registry_and_working_for_async_actors_for_fsm_instance_and_worklet(jsonb, text, text) exists');
+
+delete from fsm_core.async_operation_instance_and_async_operation_workerlet
+  where parent_fsm_name = 'crwFsm' and parent_fsm_version = 'v1';
+
+insert into fsm_core.async_operation_instance_and_async_operation_workerlet
+  (async_operation_instance_id, async_operation_name, async_operation_version, async_operation_type,
+   parent_fsm_name, parent_fsm_version, async_operation_language, status)
+values
+  (gen_random_uuid(), 'opA', '1', 'internalAsync', 'crwFsm', 'v1', 'python', 'pending');
+
+select results_eq(
+  $$ select fsm_core.check_registry_and_working_for_async_actors_for_fsm_instance_and_worklet(
+       '[{"src": "opA", "fsmVersion": "1"}]'::jsonb, 'crwFsm', 'v1') $$,
+  $$ values ('{"fsm_name": "crwFsm", "fsm_version": "v1", "all_working": true, "non_working_actors": []}'::jsonb) $$,
+  'an actor with a pending dispatch row is reported as working'
+);
+select results_eq(
+  $$ select fsm_core.check_registry_and_working_for_async_actors_for_fsm_instance_and_worklet(
+       '[{"src": "opA", "fsmVersion": "1"}, {"src": "opGone", "fsmVersion": "1"}]'::jsonb, 'crwFsm', 'v1') $$,
+  $$ values ('{"fsm_name": "crwFsm", "fsm_version": "v1", "all_working": false, "non_working_actors": [{"src": "opGone", "fsmVersion": "1"}]}'::jsonb) $$,
+  'an actor with no pending/scheduled dispatch row is reported in non_working_actors'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250119124637_fsm_scheduler_dispatch.sql
+++ b/packages/database-src/supabase/tests/20250119124637_fsm_scheduler_dispatch.sql
@@ -1,0 +1,25 @@
+begin;
+select plan(3);
+
+-- Note: fsm_core.enqueue_fsm_dispatch_v1 is intentionally not tested here —
+-- the schema file itself marks it "NOT USED — superseded by v2, preserved for
+-- historical reference only".
+select has_function('fsm_core', 'enqueue_fsm_dispatch_v2', ARRAY['uuid', 'text', 'text', 'text'],
+  'enqueue_fsm_dispatch_v2(uuid, text, text, text) exists');
+
+delete from fsm_core.fsm_instance_and_fsm_workerlet where fsm_name = 'dispatchFsm' and fsm_version = 'v1';
+
+select lives_ok(
+  $$ select fsm_core.enqueue_fsm_dispatch_v2(
+       '88888888-8888-8888-8888-888888888888'::uuid, 'dispatchFsm', 'v1', 'start') $$,
+  'inserts the dispatch row and notifies without error'
+);
+select results_eq(
+  $$ select fsm_name, fsm_version, dispatch_type, status from fsm_core.fsm_instance_and_fsm_workerlet
+     where fsm_instance_id = '88888888-8888-8888-8888-888888888888'::uuid $$,
+  $$ values ('dispatchFsm'::text, 'v1'::text, 'start'::text, 'pending'::text) $$,
+  'inserted row matches inputs and defaults to pending status'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250119124737_fsm_schedule_next_pending.sql
+++ b/packages/database-src/supabase/tests/20250119124737_fsm_schedule_next_pending.sql
@@ -1,0 +1,70 @@
+begin;
+select plan(8);
+
+select has_function('fsm_core', 'schedule_next_pending', ARRAY['integer'],
+  'schedule_next_pending(integer) exists');
+
+-- Isolate from any pre-existing rows in the shared local dev database.
+delete from fsm_core.fsm_instance_and_fsm_workerlet;
+delete from fsm_core.fsm_workerlet;
+
+select results_eq(
+  $$ select fsm_core.schedule_next_pending() $$,
+  $$ values (false) $$,
+  'empty dispatch queue: nothing to schedule'
+);
+
+insert into fsm_core.fsm_instance_and_fsm_workerlet (fsm_instance_id, fsm_name, fsm_version)
+values ('22222222-2222-2222-2222-222222222222'::uuid, 'schedFsm', '1');
+
+select results_eq(
+  $$ select fsm_core.schedule_next_pending() $$,
+  $$ values (false) $$,
+  'pending entry exists but no fsmlet is registered: nothing to schedule'
+);
+select results_eq(
+  $$ select status from fsm_core.fsm_instance_and_fsm_workerlet
+     where fsm_instance_id = '22222222-2222-2222-2222-222222222222'::uuid $$,
+  $$ values ('pending'::text) $$,
+  'entry remains pending when no fsmlet is available'
+);
+
+-- A fsmlet that does not have this FSM module loaded at all.
+insert into fsm_core.fsm_workerlet
+  (fsm_workerlet_id, fsm_workerlet_pid, fsm_modules, max_concurrency, active_workers, last_heartbeat)
+values
+  ('44444444-4444-4444-4444-444444444444'::uuid, 'pid-other',
+   '[{"fsm_name": "somethingElse", "fsm_version": "1"}]'::jsonb, 8, 0, now());
+
+select results_eq(
+  $$ select fsm_core.schedule_next_pending() $$,
+  $$ values (false) $$,
+  'a fsmlet that does not have this FSM module loaded is not chosen'
+);
+
+-- A capable fsmlet, but its heartbeat is 60s stale.
+insert into fsm_core.fsm_workerlet
+  (fsm_workerlet_id, fsm_workerlet_pid, fsm_modules, max_concurrency, active_workers, last_heartbeat)
+values
+  ('11111111-1111-1111-1111-111111111111'::uuid, 'pid-capable',
+   '[{"fsm_name": "schedFsm", "fsm_version": "1"}]'::jsonb, 8, 0, now() - interval '60 seconds');
+
+select results_eq(
+  $$ select fsm_core.schedule_next_pending(30) $$,
+  $$ values (false) $$,
+  'a capable fsmlet with a stale (60s) heartbeat is excluded under the default 30s threshold'
+);
+select results_eq(
+  $$ select fsm_core.schedule_next_pending(90) $$,
+  $$ values (true) $$,
+  'the same fsmlet is accepted once the staleness threshold is widened to 90s'
+);
+select results_eq(
+  $$ select status, fsm_workerlet_id from fsm_core.fsm_instance_and_fsm_workerlet
+     where fsm_instance_id = '22222222-2222-2222-2222-222222222222'::uuid $$,
+  $$ values ('scheduled'::text, '11111111-1111-1111-1111-111111111111'::uuid) $$,
+  'a successful schedule assigns the capable fsmlet and flips status to scheduled'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250119124837_fsm_claim_scheduled_for_fsmlet.sql
+++ b/packages/database-src/supabase/tests/20250119124837_fsm_claim_scheduled_for_fsmlet.sql
@@ -1,0 +1,47 @@
+begin;
+select plan(6);
+
+select has_function('fsm_core', 'claim_scheduled_for_fsmlet', ARRAY['uuid'],
+  'claim_scheduled_for_fsmlet(uuid) exists');
+
+delete from fsm_core.fsm_instance_and_fsm_workerlet;
+
+select results_eq(
+  $$ select fsm_core.claim_scheduled_for_fsmlet('11111111-1111-1111-1111-111111111111'::uuid) $$,
+  $$ values (null::jsonb) $$,
+  'nothing scheduled for this fsmlet: claim returns null'
+);
+
+insert into fsm_core.fsm_instance_and_fsm_workerlet
+  (fsm_instance_and_fsm_workerlet_id, fsm_instance_id, fsm_workerlet_id, fsm_name, fsm_version, dispatch_type, status, scheduled_at)
+values
+  ('55555555-5555-5555-5555-555555555555'::uuid, '22222222-2222-2222-2222-222222222222'::uuid,
+   '11111111-1111-1111-1111-111111111111'::uuid, 'schedFsm', '1', 'start', 'scheduled', now()),
+  ('66666666-6666-6666-6666-666666666666'::uuid, '77777777-7777-7777-7777-777777777777'::uuid,
+   '99999999-9999-9999-9999-999999999999'::uuid, 'otherFsm', '1', 'resume', 'scheduled', now());
+
+select results_eq(
+  $$ select (fsm_core.claim_scheduled_for_fsmlet('11111111-1111-1111-1111-111111111111'::uuid) ->> 'fsm_instance_id')::uuid $$,
+  $$ values ('22222222-2222-2222-2222-222222222222'::uuid) $$,
+  'claim returns the row scheduled for this specific fsmlet'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_instance_and_fsm_workerlet
+     where fsm_instance_and_fsm_workerlet_id = '55555555-5555-5555-5555-555555555555'::uuid $$,
+  $$ values (0::bigint) $$,
+  'the claimed row is deleted (atomic claim-and-remove)'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_instance_and_fsm_workerlet
+     where fsm_instance_and_fsm_workerlet_id = '66666666-6666-6666-6666-666666666666'::uuid $$,
+  $$ values (1::bigint) $$,
+  'a row scheduled for a different fsmlet is left untouched'
+);
+select results_eq(
+  $$ select fsm_core.claim_scheduled_for_fsmlet('11111111-1111-1111-1111-111111111111'::uuid) $$,
+  $$ values (null::jsonb) $$,
+  'claiming again for the same fsmlet returns null (already claimed)'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250119134637_fsm_instance.sql
+++ b/packages/database-src/supabase/tests/20250119134637_fsm_instance.sql
@@ -1,0 +1,42 @@
+begin;
+select plan(32);
+
+-- fsm_core.fsm_instance
+select has_table('fsm_core', 'fsm_instance', 'fsm_core.fsm_instance exists');
+select col_is_pk('fsm_core', 'fsm_instance', 'id', 'fsm_instance.id is the primary key');
+select has_column('fsm_core', 'fsm_instance', 'fsm_name', 'has fsm_name column');
+select has_column('fsm_core', 'fsm_instance', 'fsm_version', 'has fsm_version column');
+select has_column('fsm_core', 'fsm_instance', 'fsm_type', 'has fsm_type column');
+select col_type_is('fsm_core', 'fsm_instance', 'fsm_instance_context', 'jsonb', 'fsm_instance_context is jsonb');
+select col_type_is('fsm_core', 'fsm_instance', 'fsm_instance_state', 'jsonb', 'fsm_instance_state is jsonb');
+select col_type_is('fsm_core', 'fsm_instance', 'fsm_instance_status', 'jsonb', 'fsm_instance_status is jsonb');
+select col_type_is('fsm_core', 'fsm_instance', 'fsm_instance_output', 'jsonb', 'fsm_instance_output is jsonb');
+select col_type_is('fsm_core', 'fsm_instance', 'fsm_instance_error', 'jsonb', 'fsm_instance_error is jsonb');
+select col_type_is('fsm_core', 'fsm_instance', 'fsm_instance_xstate_state', 'jsonb', 'fsm_instance_xstate_state is jsonb');
+select has_column('fsm_core', 'fsm_instance', 'total_schedule_queue_data', 'has total_schedule_queue_data column');
+select has_column('fsm_core', 'fsm_instance', 'total_promise_queue_data', 'has total_promise_queue_data column');
+select col_type_is('fsm_core', 'fsm_instance', 'parent', 'uuid', 'parent is uuid');
+select has_column('fsm_core', 'fsm_instance', 'childrens', 'has childrens column');
+select has_column('fsm_core', 'fsm_instance', 'started_at', 'has started_at column');
+select has_column('fsm_core', 'fsm_instance', 'ended_at', 'has ended_at column');
+select col_type_is('fsm_core', 'fsm_instance', 'worker_locked', 'boolean', 'worker_locked is boolean');
+select has_column('fsm_core', 'fsm_instance', 'worker_locked_by', 'has worker_locked_by column');
+select has_column('fsm_core', 'fsm_instance', 'worker_locked_at', 'has worker_locked_at column');
+select has_column('fsm_core', 'fsm_instance', 'worker_lock_expires_at', 'has worker_lock_expires_at column');
+
+-- fsm_core.fsm_instance_transitions_auth
+select has_table('fsm_core', 'fsm_instance_transitions_auth', 'fsm_core.fsm_instance_transitions_auth exists');
+select has_column('fsm_core', 'fsm_instance_transitions_auth', 'fsm_name', 'has fsm_name column');
+select has_column('fsm_core', 'fsm_instance_transitions_auth', 'fsm_version', 'has fsm_version column');
+select has_column('fsm_core', 'fsm_instance_transitions_auth', 'fsm_type', 'has fsm_type column');
+select col_type_is('fsm_core', 'fsm_instance_transitions_auth', 'fsm_instance_id', 'uuid', 'fsm_instance_id is uuid');
+select fk_ok('fsm_core', 'fsm_instance_transitions_auth', 'fsm_instance_id', 'fsm_core', 'fsm_instance', 'id',
+  'fsm_instance_id references fsm_core.fsm_instance(id)');
+select has_column('fsm_core', 'fsm_instance_transitions_auth', 'fsm_instance_event_type', 'has fsm_instance_event_type column');
+select col_type_is('fsm_core', 'fsm_instance_transitions_auth', 'users', 'jsonb[]', 'users is jsonb[]');
+select col_type_is('fsm_core', 'fsm_instance_transitions_auth', 'groups', 'jsonb[]', 'groups is jsonb[]');
+select has_column('fsm_core', 'fsm_instance_transitions_auth', 'module_tag', 'has module_tag column');
+select has_column('fsm_core', 'fsm_instance_transitions_auth', 'meta_info', 'has meta_info column');
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250119144637_fsm_instance_lock.sql
+++ b/packages/database-src/supabase/tests/20250119144637_fsm_instance_lock.sql
@@ -1,0 +1,56 @@
+begin;
+select plan(15);
+
+-- Tier 1: structural
+select has_table('fsm_core', 'fsm_instance_lock', 'fsm_core.fsm_instance_lock exists');
+select col_is_pk('fsm_core', 'fsm_instance_lock', 'fsm_instance_id', 'fsm_instance_id is the primary key');
+select fk_ok('fsm_core', 'fsm_instance_lock', 'fsm_instance_id', 'fsm_core', 'fsm_instance', 'id',
+  'fsm_instance_id references fsm_core.fsm_instance(id)');
+select has_column('fsm_core', 'fsm_instance_lock', 'locked', 'has locked column');
+select has_column('fsm_core', 'fsm_instance_lock', 'locked_by', 'has locked_by column');
+select has_column('fsm_core', 'fsm_instance_lock', 'locked_at', 'has locked_at column');
+select has_column('fsm_core', 'fsm_instance_lock', 'expires_at', 'has expires_at column');
+select has_function('fsm_core', 'lock_fsm_instance', ARRAY['uuid', 'text'], 'lock_fsm_instance(uuid, text) exists');
+select has_function('fsm_core', 'unlock_fsm_instance', ARRAY['uuid'], 'unlock_fsm_instance(uuid) exists');
+
+-- Tier 2: behavioral — lock_fsm_instance/unlock_fsm_instance actually operate on
+-- fsm_core.fsm_instance's own worker_locked* columns (not the fsm_instance_lock
+-- table above, which these functions do not touch).
+insert into fsm_core.fsm_instance (id, fsm_name, fsm_version)
+values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, 'lockFsm', 'v1');
+
+select results_eq(
+  $$ select fsm_core.lock_fsm_instance('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, 'pid1') $$,
+  $$ values (true) $$,
+  'locking a fresh (unlocked) instance succeeds'
+);
+select results_eq(
+  $$ select worker_locked, worker_locked_by from fsm_core.fsm_instance
+     where id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid $$,
+  $$ values (true, 'pid1'::text) $$,
+  'the instance row reflects the lock and its owner'
+);
+select results_eq(
+  $$ select fsm_core.lock_fsm_instance('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, 'pid2') $$,
+  $$ values (false) $$,
+  'locking an already-locked instance fails'
+);
+select results_eq(
+  $$ select fsm_core.unlock_fsm_instance('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid) $$,
+  $$ values (true) $$,
+  'unlocking a locked instance succeeds'
+);
+select results_eq(
+  $$ select worker_locked, worker_locked_by from fsm_core.fsm_instance
+     where id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid $$,
+  $$ values (false, NULL::text) $$,
+  'the instance row reflects the unlock and clears the owner'
+);
+select results_eq(
+  $$ select fsm_core.unlock_fsm_instance('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid) $$,
+  $$ values (false) $$,
+  'unlocking an already-unlocked instance fails'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250120134638_fsm_instance_queue_event_logs.sql
+++ b/packages/database-src/supabase/tests/20250120134638_fsm_instance_queue_event_logs.sql
@@ -1,0 +1,25 @@
+begin;
+select plan(17);
+
+select has_table('fsm_core', 'fsm_instance_queue_event_logs', 'fsm_core.fsm_instance_queue_event_logs exists');
+select col_is_pk('fsm_core', 'fsm_instance_queue_event_logs', 'fsm_instance_queue_event_log_id',
+  'fsm_instance_queue_event_log_id is the primary key');
+select fk_ok('fsm_core', 'fsm_instance_queue_event_logs', 'fsm_instance_id', 'fsm_core', 'fsm_instance', 'id',
+  'fsm_instance_id references fsm_core.fsm_instance(id)');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'fsm_instance_id_fsm_type', 'has fsm_instance_id_fsm_type column');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'fsm_instance_id_fsm_version', 'has fsm_instance_id_fsm_version column');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'fsm_instance_queue_msg_id', 'has fsm_instance_queue_msg_id column');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'event_name', 'has event_name column');
+select col_type_is('fsm_core', 'fsm_instance_queue_event_logs', 'event_data', 'jsonb', 'event_data is jsonb');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'event_delay', 'has event_delay column');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'send_to_parent_queue_id', 'has send_to_parent_queue_id column');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'send_to_parent_queue_id_event_name', 'has send_to_parent_queue_id_event_name column');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'execution_started_at', 'has execution_started_at column');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'execution_duration', 'has execution_duration column');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'execution_finished_at', 'has execution_finished_at column');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'event_status', 'has event_status column');
+select col_type_is('fsm_core', 'fsm_instance_queue_event_logs', 'event_output', 'jsonb', 'event_output is jsonb');
+select has_column('fsm_core', 'fsm_instance_queue_event_logs', 'error_message', 'has error_message column');
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250121134639_promise_queue_event_logs.sql
+++ b/packages/database-src/supabase/tests/20250121134639_promise_queue_event_logs.sql
@@ -1,0 +1,26 @@
+begin;
+select plan(18);
+
+select has_table('fsm_core', 'fsm_promise_queue_event_logs', 'fsm_core.fsm_promise_queue_event_logs exists');
+select col_is_pk('fsm_core', 'fsm_promise_queue_event_logs', 'promise_queue_event_log_id',
+  'promise_queue_event_log_id is the primary key');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'promise_queue_name', 'has promise_queue_name column');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'promise_fn_name', 'has promise_fn_name column');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'promise_queue_type', 'has promise_queue_type column');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'promise_queue_version', 'has promise_queue_version column');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'promise_queue_msg_id', 'has promise_queue_msg_id column');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'event_name', 'has event_name column');
+select col_type_is('fsm_core', 'fsm_promise_queue_event_logs', 'event_data', 'jsonb', 'event_data is jsonb');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'event_delay', 'has event_delay column');
+select fk_ok('fsm_core', 'fsm_promise_queue_event_logs', 'send_to_parent_queue_id', 'fsm_core', 'fsm_instance', 'id',
+  'send_to_parent_queue_id references fsm_core.fsm_instance(id)');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'send_to_parent_queue_id_event_name', 'has send_to_parent_queue_id_event_name column');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'execution_started_at', 'has execution_started_at column');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'execution_duration', 'has execution_duration column');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'execution_finished_at', 'has execution_finished_at column');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'event_status', 'has event_status column');
+select col_type_is('fsm_core', 'fsm_promise_queue_event_logs', 'event_output', 'jsonb', 'event_output is jsonb');
+select has_column('fsm_core', 'fsm_promise_queue_event_logs', 'error_message', 'has error_message column');
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250219134650_fsm_instance_create_and_send_operation_v2.sql
+++ b/packages/database-src/supabase/tests/20250219134650_fsm_instance_create_and_send_operation_v2.sql
@@ -1,0 +1,89 @@
+begin;
+select plan(11);
+
+select has_function('fsm_core', 'send_event_to_fsm_queue_with_event_logs_v2',
+  ARRAY['uuid', 'text', 'text', 'uuid', 'text', 'text', 'text', 'text', 'jsonb', 'integer', 'text', 'jsonb', 'text', 'timestamptz', 'integer', 'timestamptz'],
+  'send_event_to_fsm_queue_with_event_logs_v2(...) exists');
+select has_function('fsm_core', 'create_fsm_instance_from_name_v2', ARRAY['text', 'text', 'jsonb', 'boolean'],
+  'create_fsm_instance_from_name_v2(text, text, jsonb, boolean) exists');
+
+select throws_ok(
+  $$ select fsm_core.send_event_to_fsm_queue_with_event_logs_v2(
+       NULL, 'FSM', 'v1', gen_random_uuid(), 'sys', 'evt', 'NEXT', 'system', '{}'::jsonb) $$,
+  'P0001',
+  'fsm_instance_id is NULL',
+  'a NULL fsm_instance_id is rejected up front'
+);
+select throws_ok(
+  $$ select fsm_core.send_event_to_fsm_queue_with_event_logs_v2(
+       '99999999-1111-2222-3333-444444444444'::uuid, 'FSM', 'v1', gen_random_uuid(), 'sys', 'evt', 'NEXT', 'system', '{}'::jsonb) $$,
+  'P0001',
+  'pgmq.send failed for queue 99999999-1111-2222-3333-444444444444: relation "pgmq.q_99999999-1111-2222-3333-444444444444" does not exist',
+  'sending to a queue that was never created raises a wrapped pgmq error'
+);
+
+delete from fsm_core.fsm_instance_queue_event_logs where fsm_instance_id = '99999999-1111-2222-3333-444444444444'::uuid;
+delete from fsm_core.fsm_instance where id = '99999999-1111-2222-3333-444444444444'::uuid;
+insert into fsm_core.fsm_instance (id, fsm_name, fsm_version)
+values ('99999999-1111-2222-3333-444444444444'::uuid, 'sendFsm', 'v1');
+select pgmq.create(queue_name := '99999999-1111-2222-3333-444444444444');
+
+select results_eq(
+  $$ select (r->>'event_status'), (r->'queue_data'->>'queueId')::uuid, (r->'queue_data'->'eventData'->>'eventType')
+     from fsm_core.send_event_to_fsm_queue_with_event_logs_v2(
+       '99999999-1111-2222-3333-444444444444'::uuid, 'FSM', 'v1',
+       '00000000-0000-0000-0000-000000000000'::uuid, 'POSTGRES_INTERNAL', 'sysEvt',
+       'NEXT', 'system', '{"foo": "bar"}'::jsonb) r $$,
+  $$ values ('ACTIVE'::text, '99999999-1111-2222-3333-444444444444'::uuid, 'NEXT'::text) $$,
+  'a successful send returns ACTIVE status, the queue id, and the event type'
+);
+select results_eq(
+  $$ select fsm_instance_id_fsm_type, fsm_instance_id_fsm_version, event_name, event_data, event_status
+     from fsm_core.fsm_instance_queue_event_logs
+     where fsm_instance_id = '99999999-1111-2222-3333-444444444444'::uuid $$,
+  $$ values ('FSM'::text, 'v1'::text, 'NEXT'::text, '{"foo": "bar"}'::jsonb, 'ACTIVE'::text) $$,
+  'a successful send is also logged in fsm_instance_queue_event_logs'
+);
+
+select throws_ok(
+  $$ select fsm_core.create_fsm_instance_from_name_v2('unknownFsm', 'v9', '{}'::jsonb, false) $$,
+  'P0001',
+  'FSM with name unknownFsm and version v9 not found in fsm_core.fsm_json',
+  'creating an instance of an unregistered FSM raises'
+);
+
+delete from fsm_core.fsm_transitions where fsm_name = 'createFsm' and fsm_version = 'v1';
+delete from fsm_core.fsm_json where fsm_name = 'createFsm' and fsm_version = 'v1';
+insert into fsm_core.fsm_json (fsm_name, fsm_type, fsm_version, fsm_json)
+values ('createFsm', 'FSM', 'v1', '{"id": "createFsm"}'::jsonb);
+insert into fsm_core.fsm_transitions (source, computed_sanitized_source_ltree, event_type, fsm_name, fsm_version)
+values ('#createFsm', 'createFsm', 'NEXT', 'createFsm', 'v1');
+
+select results_eq(
+  $$ select (fsm_core.create_fsm_instance_from_name_v2('createFsm', 'v1', '{"foo": "bar"}'::jsonb, false) - 'fsm_instance_id') $$,
+  $$ values ('{
+       "message": "queue_created is false and no queue is created.",
+       "fsm_name": "createFsm", "fsm_version": "v1", "extra_message": null,
+       "queue_created": false, "send_event_result": null,
+       "fsm_instance_context": {"foo": "bar"}
+     }'::jsonb) $$,
+  'creating an instance without a queue reports queue_created=false and no send_event_result'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_instance where fsm_name = 'createFsm' and fsm_version = 'v1' $$,
+  $$ values (1::bigint) $$,
+  'exactly one fsm_instance row is created'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_instance_transitions_auth where fsm_name = 'createFsm' and fsm_version = 'v1' $$,
+  $$ values (1::bigint) $$,
+  'the FSM''s transition is copied into fsm_instance_transitions_auth'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_instance_and_fsm_workerlet where fsm_name = 'createFsm' and fsm_version = 'v1' $$,
+  $$ values (1::bigint) $$,
+  'the new instance is enqueued for dispatch'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250219134651_promise_send_operation_v2.sql
+++ b/packages/database-src/supabase/tests/20250219134651_promise_send_operation_v2.sql
@@ -1,0 +1,42 @@
+begin;
+select plan(5);
+
+select has_function('fsm_core', 'send_event_to_promise_queue_with_event_logs_v2',
+  ARRAY['text', 'text', 'text', 'text', 'uuid', 'text', 'text', 'text', 'text', 'jsonb', 'integer', 'text', 'jsonb', 'text', 'timestamptz', 'integer', 'timestamptz'],
+  'send_event_to_promise_queue_with_event_logs_v2(...) exists');
+
+select throws_ok(
+  $$ select fsm_core.send_event_to_promise_queue_with_event_logs_v2(
+       NULL, 'myFn', 'promise', 'v1', gen_random_uuid(), 'sys', 'evt', 'NEXT', 'system', '{}'::jsonb) $$,
+  'P0001',
+  'promise_queue_name is NULL',
+  'a NULL promise_queue_name is rejected up front'
+);
+select throws_ok(
+  $$ select fsm_core.send_event_to_promise_queue_with_event_logs_v2(
+       'promiseQ1', 'myFn', 'promise', 'v1', gen_random_uuid(), 'sys', 'evt', 'NEXT', 'system', '{}'::jsonb) $$,
+  'P0001',
+  'pgmq.send failed for queue promiseQ1: relation "pgmq.q_promiseq1" does not exist',
+  'sending to a queue that was never created raises a wrapped pgmq error'
+);
+
+delete from fsm_core.fsm_promise_queue_event_logs where promise_queue_name = 'promiseQ1';
+select pgmq.create(queue_name := 'promiseQ1');
+
+select results_eq(
+  $$ select (r->>'event_status'), (r->'queue_data'->>'queueId'), (r->'queue_data'->'eventData'->>'eventType')
+     from fsm_core.send_event_to_promise_queue_with_event_logs_v2(
+       'promiseQ1', 'myFn', 'promise', 'v1', NULL, 'sys', 'evt', 'NEXT', 'system', '{"foo": "bar"}'::jsonb) r $$,
+  $$ values ('ACTIVE'::text, 'promiseQ1'::text, 'NEXT'::text) $$,
+  'a successful send returns ACTIVE status, the queue id, and the event type'
+);
+select results_eq(
+  $$ select promise_fn_name, event_name, event_data, event_status
+     from fsm_core.fsm_promise_queue_event_logs
+     where promise_queue_name = 'promiseQ1' $$,
+  $$ values ('myFn'::text, 'NEXT'::text, '{"foo": "bar"}'::jsonb, 'ACTIVE'::text) $$,
+  'a successful send is also logged in fsm_promise_queue_event_logs'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250219134652_fsm_instance_value_v2.sql
+++ b/packages/database-src/supabase/tests/20250219134652_fsm_instance_value_v2.sql
@@ -1,0 +1,45 @@
+begin;
+select plan(4);
+
+select has_function('fsm_core', 'get_fsm_data_resolve_state_value_v2', ARRAY['text'],
+  'get_fsm_data_resolve_state_value_v2(text) exists');
+
+select throws_ok(
+  $$ select fsm_core.get_fsm_data_resolve_state_value_v2('00000000-0000-0000-0000-000000000099') $$,
+  'P0001',
+  '[get_fsm_data_resolve_state_value_v2] No fsm_instance found for id=00000000-0000-0000-0000-000000000099',
+  'an unknown fsm_instance id raises'
+);
+
+-- Reuse the parallel-state fixture (compound root -> parallel p1 -> atomic c1/c2).
+delete from fsm_core.fsm_instance where fsm_name = 'sv' and fsm_version = 'tv1';
+delete from fsm_core.fsm_states where fsm_name = 'sv' and fsm_version = 'tv1';
+
+insert into fsm_core.fsm_states
+  (state_id_with_fsm_name_and_fsm_version, computed_state_id_ltree, computed_state_key_ltree,
+   id, key, parent_node, type, fsm_order, initial, states, fsm_name, fsm_version)
+values
+  ('sv.tv1.root', 'root', 'root', 'root', 'root', NULL, 'compound', 1,
+   '{"target": ["#root.p1"], "source": "#root"}'::jsonb, NULL, 'sv', 'tv1'),
+  ('sv.tv1.root.p1', 'root.p1', 'root.p1', 'root.p1', 'p1', 'root', 'parallel', 2,
+   NULL, '{"c1": {"id": "root.p1.c1", "key": "c1"}, "c2": {"id": "root.p1.c2", "key": "c2"}}'::jsonb, 'sv', 'tv1'),
+  ('sv.tv1.root.p1.c1', 'root.p1.c1', 'root.p1.c1', 'root.p1.c1', 'c1', 'root.p1', 'atomic', 3, NULL, NULL, 'sv', 'tv1'),
+  ('sv.tv1.root.p1.c2', 'root.p1.c2', 'root.p1.c2', 'root.p1.c2', 'c2', 'root.p1', 'atomic', 4, NULL, NULL, 'sv', 'tv1');
+
+insert into fsm_core.fsm_instance (id, fsm_name, fsm_version, fsm_instance_state)
+values ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, 'sv', 'tv1', '{"p1": "c1"}'::jsonb);
+
+select results_eq(
+  $$ select (r->'fsm_instance_row'->>'id')::uuid, (r->'fsm_instance_row'->>'fsm_name'), (r->'fsm_instance_row'->>'fsm_version')
+     from fsm_core.get_fsm_data_resolve_state_value_v2('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb') r $$,
+  $$ values ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, 'sv'::text, 'tv1'::text) $$,
+  'the result embeds the looked-up fsm_instance row'
+);
+select results_eq(
+  $$ select r->'resolved_state_value' from fsm_core.get_fsm_data_resolve_state_value_v2('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb') r $$,
+  $$ values ('{"json": {"root": {"p1": "c1"}}, "all_nodes": ["root.p1.c1", "root.p1.c2", "root.p1.c1"]}'::jsonb) $$,
+  'the result embeds resolve_state_value_v2''s output for the instance''s current state'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250219134662_cancle_event_for_fsm_promise_worker_v2.sql
+++ b/packages/database-src/supabase/tests/20250219134662_cancle_event_for_fsm_promise_worker_v2.sql
@@ -1,0 +1,37 @@
+begin;
+select plan(5);
+
+select has_function('fsm_core', 'cancel_event_for_fsm_promise_type_worker_v2', ARRAY['text', 'bigint'],
+  'cancel_event_for_fsm_promise_type_worker_v2(text, bigint) exists');
+
+delete from fsm_core.fsm_promise_queue_event_logs where promise_queue_name in ('cancelQ1', 'cancelQ2');
+select pgmq.create(queue_name := 'cancelQ1');
+select pgmq.send(queue_name := 'cancelQ1', msg := '{"foo": "bar"}'::jsonb);
+
+select results_eq(
+  $$ select fsm_core.cancel_event_for_fsm_promise_type_worker_v2('cancelQ1', 1::bigint) $$,
+  $$ values ('{"status": "canceled", "queue_msg_id": 1, "archive_result": true, "promise_queue_name": "cancelQ1"}'::jsonb) $$,
+  'canceling an existing queued message archives it and reports archive_result=true'
+);
+select results_eq(
+  $$ select event_name, promise_queue_msg_id, event_status from fsm_core.fsm_promise_queue_event_logs
+     where promise_queue_name = 'cancelQ1' $$,
+  $$ values ('cancel'::text, 1::bigint, 'canceled'::text) $$,
+  'a cancel event is logged in fsm_promise_queue_event_logs'
+);
+
+select pgmq.create(queue_name := 'cancelQ2');
+select results_eq(
+  $$ select (fsm_core.cancel_event_for_fsm_promise_type_worker_v2('cancelQ2', 999::bigint) ->> 'archive_result')::boolean $$,
+  $$ values (false) $$,
+  'canceling a message id that does not exist in an otherwise-valid queue reports archive_result=false (no exception)'
+);
+select throws_ok(
+  $$ select fsm_core.cancel_event_for_fsm_promise_type_worker_v2('neverCreatedQueue', 1::bigint) $$,
+  '42P01',
+  'relation "pgmq.q_nevercreatedqueue" does not exist',
+  'canceling against a queue that was never created raises the raw pgmq relation-not-found error (not wrapped)'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250219134672_stop_event_for_fsm_worker_v2.sql
+++ b/packages/database-src/supabase/tests/20250219134672_stop_event_for_fsm_worker_v2.sql
@@ -1,0 +1,57 @@
+begin;
+select plan(8);
+
+-- Note: fsm_core.stop_event_for_fsm_worker_v1 is intentionally not tested here
+-- — the schema file itself notes it was "renamed from the original _v2" and is
+-- the legacy pgmq/in-process worker flow, superseded by the scheduler-model v2.
+select has_function('fsm_core', 'stop_event_for_fsm_worker_v2', ARRAY['uuid'],
+  'stop_event_for_fsm_worker_v2(uuid) exists');
+select has_function('fsm_core', 'resume_event_for_fsm_worker_v2', ARRAY['uuid'],
+  'resume_event_for_fsm_worker_v2(uuid) exists');
+
+delete from fsm_core.fsm_instance_and_fsm_workerlet where fsm_name = 'stopFsm' and fsm_version = 'v1';
+delete from fsm_core.fsm_instance_queue_event_logs
+  where fsm_instance_id in (select id from fsm_core.fsm_instance where fsm_name = 'stopFsm' and fsm_version = 'v1');
+delete from fsm_core.fsm_instance where fsm_name = 'stopFsm' and fsm_version = 'v1';
+insert into fsm_core.fsm_instance (id, fsm_name, fsm_version)
+values ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'stopFsm', 'v1');
+
+select results_eq(
+  $$ select fsm_core.stop_event_for_fsm_worker_v2('00000000-0000-0000-0000-000000000098'::uuid) $$,
+  $$ values ('{"status": "fsm_not_found", "fsm_instance_id": "00000000-0000-0000-0000-000000000098"}'::jsonb) $$,
+  'stopping an unknown instance reports fsm_not_found'
+);
+select results_eq(
+  $$ select (fsm_core.stop_event_for_fsm_worker_v2('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid) - 'event_log_id') $$,
+  $$ values ('{"status": "not_queued", "cancelled_count": 0, "fsm_instance_id": "cccccccc-cccc-cccc-cccc-cccccccccccc"}'::jsonb) $$,
+  'stopping an instance with no pending/scheduled dispatch entry reports not_queued'
+);
+
+insert into fsm_core.fsm_instance_and_fsm_workerlet (fsm_instance_id, fsm_name, fsm_version, status)
+values ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'stopFsm', 'v1', 'pending');
+
+select results_eq(
+  $$ select (fsm_core.stop_event_for_fsm_worker_v2('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid) - 'event_log_id') $$,
+  $$ values ('{"status": "cancelled", "cancelled_count": 1, "fsm_instance_id": "cccccccc-cccc-cccc-cccc-cccccccccccc"}'::jsonb) $$,
+  'stopping an instance with a pending dispatch entry cancels it'
+);
+select results_eq(
+  $$ select count(*) from fsm_core.fsm_instance_and_fsm_workerlet
+     where fsm_instance_id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid $$,
+  $$ values (0::bigint) $$,
+  'the cancelled dispatch row is actually deleted'
+);
+
+select results_eq(
+  $$ select fsm_core.resume_event_for_fsm_worker_v2('00000000-0000-0000-0000-000000000098'::uuid) $$,
+  $$ values ('{"status": "fsm_not_found", "fsm_instance_id": "00000000-0000-0000-0000-000000000098"}'::jsonb) $$,
+  'resuming an unknown instance reports fsm_not_found'
+);
+select results_eq(
+  $$ select fsm_core.resume_event_for_fsm_worker_v2('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid) $$,
+  $$ values ('{"status": "queued", "fsm_name": "stopFsm", "fsm_version": "v1", "fsm_instance_id": "cccccccc-cccc-cccc-cccc-cccccccccccc"}'::jsonb) $$,
+  'resuming a known instance re-enqueues it with its own fsm_name/version'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250219134752_archive_from_promise_worker_v2.sql
+++ b/packages/database-src/supabase/tests/20250219134752_archive_from_promise_worker_v2.sql
@@ -1,0 +1,54 @@
+begin;
+select plan(5);
+
+select has_function('fsm_core', 'archive_event_from_fsm_promise_type_worker_v2',
+  ARRAY['text', 'text', 'text', 'bigint', 'text', 'text', 'jsonb', 'integer', 'uuid', 'text', 'timestamptz', 'integer', 'timestamptz', 'text', 'jsonb', 'text'],
+  'archive_event_from_fsm_promise_type_worker_v2(...) exists');
+
+delete from fsm_core.fsm_promise_queue_event_logs where promise_queue_name = 'archPromiseQ1';
+delete from fsm_core.fsm_instance_queue_event_logs
+  where fsm_instance_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid;
+delete from fsm_core.fsm_instance where id = 'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid;
+insert into fsm_core.fsm_instance (id, fsm_name, fsm_version)
+values ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'archFsm', 'v1');
+select pgmq.create(queue_name := 'dddddddd-dddd-dddd-dddd-dddddddddddd');
+select pgmq.create(queue_name := 'archPromiseQ1');
+select pgmq.send(queue_name := 'archPromiseQ1', msg := '{"foo": "bar"}'::jsonb);
+
+select results_eq(
+  $$ select (r->>'promise_queue_archive_result')::boolean, (r->>'promise_queue_name'),
+            (r->>'promise_queue_msg_id')::bigint, (r->'send_to_parent_result'->'queue_data'->'eventData'->>'eventType')
+     from fsm_core.archive_event_from_fsm_promise_type_worker_v2(
+       'archPromiseQ1', 'promise', 'v1', 1::bigint,
+       'promiseDone', 'promise', '{"result": "ok"}'::jsonb, 0,
+       'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'promiseDoneEvt',
+       now(), NULL, now(), 'success', '{"result": "ok"}'::jsonb, NULL) r $$,
+  $$ values (true, 'archPromiseQ1'::text, 1::bigint, 'promiseDone'::text) $$,
+  'archiving a completed promise event: message archived, and forwarded to the parent FSM queue'
+);
+select results_eq(
+  $$ select event_name, event_data, event_status from fsm_core.fsm_promise_queue_event_logs
+     where promise_queue_name = 'archPromiseQ1' $$,
+  $$ values ('promiseDone'::text, '{"result": "ok"}'::jsonb, 'success'::text) $$,
+  'the archive is logged in fsm_promise_queue_event_logs'
+);
+select results_eq(
+  $$ select event_name, event_data, event_status from fsm_core.fsm_instance_queue_event_logs
+     where fsm_instance_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid $$,
+  $$ values ('promiseDone'::text, '{"result": "ok"}'::jsonb, 'success'::text) $$,
+  'the forwarded event is also logged against the parent fsm_instance queue'
+);
+
+select throws_ok(
+  $$ select fsm_core.archive_event_from_fsm_promise_type_worker_v2(
+       'neverCreatedPromiseQ', 'promise', 'v1', 1::bigint,
+       'promiseDone', 'promise', '{}'::jsonb, 0,
+       'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'promiseDoneEvt',
+       now(), NULL, now(), 'success', '{}'::jsonb, NULL) $$,
+  '42P01',
+  'relation "pgmq.q_nevercreatedpromiseq" does not exist',
+  'archiving from a queue that was never created raises the raw pgmq relation-not-found error (not wrapped)'
+);
+
+select * from finish();
+rollback;

--- a/packages/database-src/supabase/tests/20250219134852_archive_from_fsm_instance_worker_v2.sql
+++ b/packages/database-src/supabase/tests/20250219134852_archive_from_fsm_instance_worker_v2.sql
@@ -1,0 +1,124 @@
+begin;
+select plan(12);
+
+select has_function('fsm_core', 'create_promise_queue_and_send_event_from_fsm_instance_id_v2',
+  ARRAY['text', 'jsonb', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
+  'create_promise_queue_and_send_event_from_fsm_instance_id_v2(...) exists');
+select has_function('fsm_core', 'create_fsm_queue_and_send_event_from_fsm_instance_id_v2',
+  ARRAY['text', 'jsonb', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
+  'create_fsm_queue_and_send_event_from_fsm_instance_id_v2(...) exists');
+select has_function('fsm_core', 'send_event_to_queue_from_fsm_instance_id_v2',
+  ARRAY['text', 'jsonb', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
+  'send_event_to_queue_from_fsm_instance_id_v2(...) exists');
+select has_function('fsm_core', 'archive_event_from_fsm_type_worker_v2',
+  ARRAY['text', 'bigint', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'uuid', 'text', 'text'],
+  'archive_event_from_fsm_type_worker_v2(...) exists');
+
+delete from fsm_core.fsm_promise_queue_event_logs where promise_queue_name like 'pFsm_v1_%';
+delete from fsm_core.fsm_instance where fsm_name = 'srcFsm' and fsm_version = 'v1';
+insert into fsm_core.fsm_instance (id, fsm_name, fsm_version)
+values ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid, 'srcFsm', 'v1');
+
+select results_eq(
+  $$ select (r->>'start_queue_worker')::boolean, (r->'queue_data'->>'queueId')
+     from fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(
+       'evt1', '{"x": 1}'::jsonb, 'someId', 'invoke', 'someSrc', 'childOp', 'promise', 'v1',
+       'pFsm', 'v1', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) r $$,
+  $$ values (true, 'pFsm_v1_childOp'::text) $$,
+  'the first call for a not-yet-existing promise queue creates it (start_queue_worker=true)'
+);
+select results_eq(
+  $$ select (r->>'start_queue_worker')::boolean
+     from fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(
+       'evt2', '{"x": 2}'::jsonb, 'someId2', 'invoke', 'someSrc', 'childOp', 'promise', 'v1',
+       'pFsm', 'v1', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) r $$,
+  $$ values (false) $$,
+  'a second call for the same promise queue reuses it (start_queue_worker=false)'
+);
+select throws_ok(
+  $$ select fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(
+       'evt', '{}'::jsonb, 'id', 'invoke', 'src', 'x', 'unsupportedType', 'v1', 'p', 'v1',
+       'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) $$,
+  'P0001',
+  'create_promise_queue_and_send_event_from_fsm_instance_id_v2: unsupported fsmType: unsupportedType',
+  'an unsupported fsmType raises'
+);
+
+-- Characterization test: create_fsm_queue_and_send_event_from_fsm_instance_id_v2
+-- generates a brand-new child_instance_id via uuid_generate_v4() and immediately
+-- tries to log an event against it in fsm_instance_queue_event_logs, whose
+-- fsm_instance_id column has a foreign key to fsm_core.fsm_instance. Since that
+-- freshly generated id was never inserted into fsm_instance, this always fails
+-- with a foreign key violation as currently written. Filed as a bug (see
+-- tracking issue) — documented here rather than silently papered over.
+select throws_ok(
+  $$ select fsm_core.create_fsm_queue_and_send_event_from_fsm_instance_id_v2(
+       'childEvt', '{"x": 1}'::jsonb, 'someId', 'childFsm', 'someSrc', 'childName', 'childFsm', 'v1',
+       'parentName', 'parentV1', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) $$,
+  '23503',
+  'insert or update on table "fsm_instance_queue_event_logs" violates foreign key constraint "fsm_instance_queue_event_logs_fsm_instance_id_fkey"',
+  'create_fsm_queue_and_send_event_from_fsm_instance_id_v2 always fails: it logs against a freshly-generated child_instance_id that was never inserted into fsm_instance (foreign key violation, likely a bug)'
+);
+
+select throws_ok(
+  $$ select fsm_core.send_event_to_queue_from_fsm_instance_id_v2(
+       'evt', '{}'::jsonb, 'id', 'invoke', 'src', 'x', 'unsupportedFsmType', 'v1', 'p', 'v1',
+       'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) $$,
+  'P0001',
+  'Unsupported fsmType: unsupportedFsmType',
+  'send_event_to_queue_from_fsm_instance_id_v2 rejects an unrecognized fsmType'
+);
+
+-- Simplest case for the macro archive/save function: no schedule/promise queue
+-- churn, non-terminal status (no parent notify), just update instance state
+-- and archive the current queue message.
+delete from fsm_core.fsm_instance where fsm_name = 'archMacroFsm' and fsm_version = 'v1';
+insert into fsm_core.fsm_instance (id, fsm_name, fsm_version)
+values ('ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid, 'archMacroFsm', 'v1');
+select pgmq.create(queue_name := 'ffffffff-ffff-ffff-ffff-ffffffffffff');
+select pgmq.send(queue_name := 'ffffffff-ffff-ffff-ffff-ffffffffffff', msg := '{"foo": "bar"}'::jsonb);
+
+select results_eq(
+  $$ select fsm_core.archive_event_from_fsm_type_worker_v2(
+       'ffffffff-ffff-ffff-ffff-ffffffffffff', 1::bigint,
+       NULL, NULL, NULL, NULL, NULL, NULL,
+       '"active"'::jsonb, '{"foo": "bar"}'::jsonb, '{"ctx": 1}'::jsonb, '{"xs": 1}'::jsonb,
+       NULL, NULL, NULL) $$,
+  $$ values ('{
+       "parent_notify_result": null, "added_promise_queue_data": [], "added_schedule_queue_data": [],
+       "new_total_promise_queue_data": [], "old_total_promise_queue_data": null,
+       "new_total_schedule_queue_data": [], "old_total_schedule_queue_data": null,
+       "not_confirmed_removed_promise_queue_data": [], "not_confirmed_removed_schedule_queue_data": [],
+       "confirmed_removed_promise_queue_data_failed": [], "confirmed_removed_promise_queue_data_success": [],
+       "confirmed_removed_schedule_queue_data_failed": [], "confirmed_removed_schedule_queue_data_success": []
+     }'::jsonb) $$,
+  'with no schedule/promise churn and a non-terminal status, the result is all empty arrays and no parent notify'
+);
+select results_eq(
+  $$ select fsm_instance_status, fsm_instance_state, fsm_instance_context, fsm_instance_xstate_state,
+            total_schedule_queue_data, total_promise_queue_data
+     from fsm_core.fsm_instance where id = 'ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid $$,
+  $$ values ('"active"'::jsonb, '{"foo": "bar"}'::jsonb, '{"ctx": 1}'::jsonb, '{"xs": 1}'::jsonb, '[]'::jsonb, '[]'::jsonb) $$,
+  'the fsm_instance row is updated with the new status/state/context/xstate_state'
+);
+
+-- Terminal status + a real (non-system) parent queue triggers a parent notify.
+delete from fsm_core.fsm_instance where fsm_name = 'archParentFsm' and fsm_version = 'v1';
+insert into fsm_core.fsm_instance (id, fsm_name, fsm_version)
+values ('11112222-3333-4444-5555-666677778888'::uuid, 'archParentFsm', 'v1');
+select pgmq.create(queue_name := '11112222-3333-4444-5555-666677778888');
+select pgmq.send(queue_name := 'ffffffff-ffff-ffff-ffff-ffffffffffff', msg := '{"another": "msg"}'::jsonb);
+
+select results_eq(
+  $$ select ((fsm_core.archive_event_from_fsm_type_worker_v2(
+       'ffffffff-ffff-ffff-ffff-ffffffffffff', 2::bigint,
+       NULL, NULL, NULL, NULL, NULL, NULL,
+       '"done"'::jsonb, '{"final": true}'::jsonb, '{"ctx": 1}'::jsonb, '{"xs": 1}'::jsonb,
+       '11112222-3333-4444-5555-666677778888'::uuid, 'FSM', 'childDoneEvt'
+     ))->'parent_notify_result'->'queue_data'->'eventData'->>'eventType') $$,
+  $$ values ('childDoneEvt'::text) $$,
+  'a terminal status with a real parent queue id sends a completion event to the parent'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- Adds pgTAP tests for all 45 live schema files in `packages/database-src/supabase/schemas/` — the full FSM execution engine (json/ltree helpers, load, state values, exit/entry actions, microstep/macrostep), async operation and scheduler tables/functions, `fsm_instance` lifecycle, and the v2 send/archive operations.
- 39 test files, 468 pgTAP assertions, verified against a fresh `supabase db reset`.
- v1-suffixed functions are skipped throughout (superseded by v2, per CLAUDE.md). The 5 fully-commented-out reference/changelog schema files have no matching test.
- Wires up `npm run supabase:test:db` (`supabase test db`) and documents the `supabase/tests/` convention in `docs/guides/development.md`.
- Two real bugs surfaced while writing tests, filed separately and documented here as characterization tests (not fixed in this PR): #32, #33.

## Test plan
- [x] `npm run supabase:test:db` — all 468 assertions pass
- [x] Re-ran after `npm run supabase:db:reset` to confirm the pgTAP bootstrap self-heals against a fresh schema
- [x] Confirmed the behavioral tests wrapped in `begin`/`rollback` leave no residual rows in the shared local dev database

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)