### PR TITLE
chore(ci): rename misleading pr-lint job id to conventions

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,7 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  conventions:
+    name: Enforce PR conventions
     # Renovate manages its own PRs; the issue-linkage convention applies to
     # human/agent work only.
     if: "!startsWith(github.head_ref, 'renovate/')"


### PR DESCRIPTION
## Summary
- The single job in `.github/workflows/pr-lint.yml` was keyed `lint`, which reads as a code-lint check ("PR Lint / lint" in the GitHub UI). It actually enforces AGENTS.md workflow conventions (branch naming, PR closing-issue reference, spec link for design PRs) — no code linting involved.
- Renamed the job id to `conventions` and added an explicit `name: Enforce PR conventions` so the check name is self-explanatory.
- Audited every other workflow's job names — all already clear, no other changes needed.

## Test plan
- [x] `prek` pre-commit hooks passed (secret scan, branch naming)
- [ ] Confirm this workflow still triggers correctly on this PR (PR Lint / Enforce PR conventions should appear as a check)
- [ ] Branch protection required status check name needs to be updated separately from `PR Lint / lint` to `PR Lint / Enforce PR conventions` (owner is handling this out of band)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)