### PR TITLE
chore(compiler-ts): model real FSM JSON types via XState + schema codegen

### DIFF
--- a/packages/database-src/fsm.machine.schema.v3.json
+++ b/packages/database-src/fsm.machine.schema.v3.json
@@ -70,8 +70,7 @@
           "type": "object",
           "properties": {
             "type": {
-              "type": "string",
-              "pattern": "compound"
+              "const": "compound"
             },
             "entry": {
               "type": "array",
@@ -109,8 +108,7 @@
           "type": "object",
           "properties": {
             "type": {
-              "type": "string",
-              "pattern": "parallel"
+              "const": "parallel"
             },
             "entry": {
               "type": "array",
@@ -145,8 +143,7 @@
           "type": "object",
           "properties": {
             "type": {
-              "type": "string",
-              "pattern": "atomic"
+              "const": "atomic"
             },
             "entry": {
               "type": "array",
@@ -178,8 +175,7 @@
           "type": "object",
           "properties": {
             "type": {
-              "type": "string",
-              "pattern": "history"
+              "const": "history"
             },
             "history": {
               "type": "string",
@@ -197,11 +193,11 @@
           "type": "object",
           "properties": {
             "type": {
-              "type": "string",
-              "pattern": "final"
+              "const": "final"
             },
             "data": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": true
             }
           }
         }
@@ -239,6 +235,9 @@
             "type": "string"
           },
           "minItems": 1
+        },
+        "eventType": {
+          "anyOf": [{ "type": "string" }, { "type": "null" }]
         }
       },
       "required": ["actions", "source", "target"]
@@ -264,7 +263,17 @@
           }
         },
         "cond": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Legacy guard payload consumed by the PostgreSQL extension's transition loader (transition->'cond'). Not emitted by this compiler, which emits `guard` instead."
+        },
+        "guard": {
+          "type": "string",
+          "description": "Name of the guard function to evaluate for this transition."
+        },
+        "delay": {
+          "anyOf": [{ "type": "string" }, { "type": "integer" }],
+          "description": "Delay identifier (xstate.after.* transitions) or duration in ms."
         },
         "eventType": {
           "type": "string"
@@ -347,7 +356,8 @@
       "enum": ["compound", "parallel"]
     },
     "context": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": true
     },
     "states": {
       "$ref": "#/$defs/statesObject"
@@ -362,10 +372,16 @@
       }
     },
     "entry": {
-      "type": "array"
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/actionObject"
+      }
     },
     "exit": {
-      "type": "array"
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/actionObject"
+      }
     },
     "order": {
       "$ref": "#/$defs/order"

--- a/packages/fsm-compiler-ts/deno.json
+++ b/packages/fsm-compiler-ts/deno.json
@@ -10,7 +10,8 @@
     "cli": "deno run --allow-all src/cli/index.ts",
     "test": "deno test --allow-all test/",
     "test:watch": "deno test --allow-all --watch test/",
-    "build:npm": "deno run --allow-all --allow-read --allow-write --allow-env --allow-run scripts/build-npm.ts"
+    "build:npm": "deno run --allow-all --allow-read --allow-write --allow-env --allow-run scripts/build-npm.ts",
+    "generate:fsm-types": "deno run --allow-read --allow-write --allow-sys --allow-env scripts/generate-fsm-json-types.ts"
   },
   "imports": {
     "@logtape/logtape": "jsr:@logtape/logtape@^2.2",
@@ -20,6 +21,7 @@
     "@types/pg": "npm:@types/pg@^8.18.0",
     "ajv": "npm:ajv@^8.18.0",
     "dotenv": "npm:dotenv@^16.5.0",
+    "json-schema-to-typescript": "npm:json-schema-to-typescript@^15.0.4",
     "pg": "npm:pg@^8.20.0",
     "type-fest": "npm:type-fest@^4.41.0",
     "uuid": "npm:uuid@^11.1.0",

--- a/packages/fsm-compiler-ts/scripts/generate-fsm-json-types.ts
+++ b/packages/fsm-compiler-ts/scripts/generate-fsm-json-types.ts
@@ -1,0 +1,25 @@
+import { compile } from "json-schema-to-typescript";
+
+const schemaPath = new URL(
+  "../../database-src/fsm.machine.schema.v3.json",
+  import.meta.url,
+);
+const outPath = new URL(
+  "../src/generated/fsm-machine-schema.types.ts",
+  import.meta.url,
+);
+
+const schema = JSON.parse(await Deno.readTextFile(schemaPath));
+
+const ts = await compile(schema, "FsmMachineJson", {
+  additionalProperties: false,
+  bannerComment:
+    "/**\n * AUTO-GENERATED — do not edit by hand.\n * Source: packages/database-src/fsm.machine.schema.v3.json\n * Regenerate with: deno task generate:fsm-types (run from packages/fsm-compiler-ts)\n */",
+});
+
+await Deno.mkdir(new URL("../src/generated", import.meta.url), {
+  recursive: true,
+});
+await Deno.writeTextFile(outPath, ts);
+
+console.log(`Wrote ${outPath.pathname}`);

--- a/packages/fsm-compiler-ts/src/delete-fsm-json-from-folders-test.ts
+++ b/packages/fsm-compiler-ts/src/delete-fsm-json-from-folders-test.ts
@@ -22,12 +22,12 @@ dotenv.config({ path: "./../../.env" });
   const skipFSMDirs = ["carVitals", "taskMachineConfig"];
   // const skipSharedFSMDirs = [];
   // const skipFSMDirs = [];
-  const outputSharedFSM = await deleteFsmJSONFromFolders(
+  await deleteFsmJSONFromFolders(
     sharedFSMfolderPath,
     "sharedFsm",
     skipSharedFSMDirs,
   );
-  const outputFSM = await deleteFsmJSONFromFolders(
+  await deleteFsmJSONFromFolders(
     fsmfolderPath,
     "fsm",
     skipFSMDirs,

--- a/packages/fsm-compiler-ts/src/delete-fsm-json-from-folders.ts
+++ b/packages/fsm-compiler-ts/src/delete-fsm-json-from-folders.ts
@@ -1,17 +1,15 @@
 import { getLogger } from "@logtape/logtape";
-import { v4 as uuidv4 } from "uuid";
-import { writeFileSync } from "node:fs";
 
 const logger = getLogger(["@pgfsm/compiler", "delete"]);
 import { isVersionFolderName, type WorkflowType } from "./util.ts";
 
 async function deleteFsmJSONFromFolder(
   dirEntryName: string,
-  dirEntryNameVersion: string,
-  folderPath: string,
+  _dirEntryNameVersion: string,
+  _folderPath: string,
   absFolderPath: string,
-  parentSource: string,
-  workflowType: WorkflowType,
+  _parentSource: string,
+  _workflowType: WorkflowType,
 ) {
   try {
     await Deno.remove(`${absFolderPath}/xstate-fsm.json`);

--- a/packages/fsm-compiler-ts/src/generate-fsm-json.ts
+++ b/packages/fsm-compiler-ts/src/generate-fsm-json.ts
@@ -1,5 +1,4 @@
 import { getLogger } from "@logtape/logtape";
-import { v4 as uuidv4 } from "uuid";
 import { writeFileSync } from "node:fs";
 
 const logger = getLogger(["@pgfsm/compiler", "generate"]);
@@ -21,14 +20,14 @@ import type { Json } from "@pgfsm/db/database.types";
  * @param obj The FSM JSON object
  * @returns A new object with nulls removed from all actions arrays
  */
-function removeNullActions(obj: any): any {
+function removeNullActions(obj: Json): Json {
   const clone = JSON.parse(JSON.stringify(obj));
 
-  function filterNulls(arr: any[]): any[] {
-    return arr.filter((a: any) => a !== null);
+  function filterNulls(arr: Json[]): Json[] {
+    return arr.filter((a: Json) => a !== null);
   }
 
-  function visitState(state: any) {
+  function visitState(state: Json) {
     if (Array.isArray(state.entry)) state.entry = filterNulls(state.entry);
     if (Array.isArray(state.exit)) state.exit = filterNulls(state.exit);
 
@@ -77,15 +76,15 @@ function removeNullActions(obj: any): any {
 export function normalizeActionsToObjects(obj: Json): Json {
   const clone = JSON.parse(JSON.stringify(obj));
 
-  function toActionObject(a: any): any {
+  function toActionObject(a: Json): Json {
     return typeof a === "string" ? { type: a } : a;
   }
 
-  function normalizeActionArray(arr: any[]): any[] {
+  function normalizeActionArray(arr: Json[]): Json[] {
     return arr.map(toActionObject);
   }
 
-  function visitState(state: any) {
+  function visitState(state: Json) {
     if (Array.isArray(state.entry)) {
       state.entry = normalizeActionArray(state.entry);
     }
@@ -139,8 +138,8 @@ export function addActionNameFromDelay(obj: Json): Json {
   const clone = JSON.parse(JSON.stringify(obj));
 
   /** Collect full transition objects whose event contains "xstate.after." and have a delay key */
-  function getAfterTransitions(state: any): any[] {
-    const afterTransitions: any[] = [];
+  function getAfterTransitions(state: Json): Json[] {
+    const afterTransitions: Json[] = [];
 
     if (state.on && typeof state.on === "object") {
       for (const eventKey of Object.keys(state.on)) {
@@ -170,7 +169,10 @@ export function addActionNameFromDelay(obj: Json): Json {
   }
 
   /** Map each xstate.raise/xstate.cancel action to the next after-transition's delay value */
-  function enrichActionArray(actions: any[], afterTransitions: any[]): any[] {
+  function enrichActionArray(
+    actions: Json[],
+    afterTransitions: Json[],
+  ): Json[] {
     let i = 0;
     return actions.map((a) => {
       if (
@@ -189,7 +191,7 @@ export function addActionNameFromDelay(obj: Json): Json {
     });
   }
 
-  function visitState(state: any) {
+  function visitState(state: Json) {
     const afterTransitions = getAfterTransitions(state);
 
     if (Array.isArray(state.entry)) {
@@ -243,7 +245,7 @@ export function addMissingFsmTypeToInvokeActors(
     }
   > = [];
 
-  function visitState(state: any) {
+  function visitState(state: Json) {
     if (Array.isArray(state.invoke)) {
       for (const invokeObj of state.invoke) {
         // Only process if src exists

--- a/packages/fsm-compiler-ts/src/generate-fsm-json.ts
+++ b/packages/fsm-compiler-ts/src/generate-fsm-json.ts
@@ -12,22 +12,66 @@ import {
   RAISE_CANCEL,
   type WorkflowType,
 } from "./util.ts";
-import type { Json } from "@pgfsm/db/database.types";
+import type { AnyStateNodeDefinition } from "xstate";
+import type {
+  ActionObject,
+  InvokeObject,
+} from "./generated/fsm-machine-schema.types.ts";
+
+/**
+ * Working shape for the compiler's internal transform pipeline — the space
+ * between raw XState `.toJSON()` output and the fully-compiled FsmMachineJson
+ * (see ./generated/fsm-machine-schema.types.ts, generated from
+ * ../../database-src/fsm.machine.schema.v3.json). Entry/exit items may still
+ * be plain strings (XState 5 action shorthand, normalized to actionObjects by
+ * normalizeActionsToObjects below) or `null` placeholders left by
+ * conditionally-skipped actions in machine.ts (stripped by
+ * removeNullActions). By the time generateFsmJSONFromMachineFile finishes the
+ * pipeline, the result should satisfy FsmMachineJson — enforced at runtime by
+ * the AJV validation in the showRecommendation step.
+ */
+type FsmDraftAction = string | ActionObject;
+
+type FsmDraftTransition = {
+  actions?: FsmDraftAction[];
+  eventType?: string;
+  delay?: string | number;
+  guard?: string;
+  source?: string;
+  target?: string[];
+};
+
+type FsmDraftInvoke = Partial<InvokeObject> & { src?: string };
+
+export type FsmDraftStateNode = {
+  id?: string;
+  key?: string;
+  type?: string;
+  entry?: FsmDraftAction[];
+  exit?: FsmDraftAction[];
+  initial?: { actions?: FsmDraftAction[]; source?: string; target?: string[] };
+  on?: Record<string, FsmDraftTransition[]>;
+  transitions?: FsmDraftTransition[];
+  invoke?: FsmDraftInvoke[];
+  states?: Record<string, FsmDraftStateNode>;
+};
 
 /**
  * Pure function — returns a new FSM JSON object with all null values removed
  * from every entry/exit/initial/on/transitions actions array. Does not mutate the input.
- * @param obj The FSM JSON object
+ * @param obj The raw XState machine definition (machineConfig.toJSON())
  * @returns A new object with nulls removed from all actions arrays
  */
-function removeNullActions(obj: Json): Json {
-  const clone = JSON.parse(JSON.stringify(obj));
+function removeNullActions(obj: AnyStateNodeDefinition): FsmDraftStateNode {
+  const clone: FsmDraftStateNode = JSON.parse(JSON.stringify(obj));
 
-  function filterNulls(arr: Json[]): Json[] {
-    return arr.filter((a: Json) => a !== null);
+  // Real .toJSON() output can contain `null` entries for conditionally
+  // skipped actions in machine.ts, which FsmDraftAction doesn't admit.
+  function filterNulls(arr: FsmDraftAction[]): FsmDraftAction[] {
+    return arr.filter((a) => (a as unknown) !== null);
   }
 
-  function visitState(state: Json) {
+  function visitState(state: FsmDraftStateNode) {
     if (Array.isArray(state.entry)) state.entry = filterNulls(state.entry);
     if (Array.isArray(state.exit)) state.exit = filterNulls(state.exit);
 
@@ -35,14 +79,11 @@ function removeNullActions(obj: Json): Json {
       state.initial.actions = filterNulls(state.initial.actions);
     }
 
-    if (state.on && typeof state.on === "object") {
+    if (state.on) {
       for (const eventKey of Object.keys(state.on)) {
-        const transitions = state.on[eventKey];
-        if (Array.isArray(transitions)) {
-          for (const transition of transitions) {
-            if (Array.isArray(transition.actions)) {
-              transition.actions = filterNulls(transition.actions);
-            }
+        for (const transition of state.on[eventKey]) {
+          if (Array.isArray(transition.actions)) {
+            transition.actions = filterNulls(transition.actions);
           }
         }
       }
@@ -55,7 +96,7 @@ function removeNullActions(obj: Json): Json {
       }
     }
 
-    if (state.states && typeof state.states === "object") {
+    if (state.states) {
       for (const subKey of Object.keys(state.states)) {
         visitState(state.states[subKey]);
       }
@@ -73,18 +114,20 @@ function removeNullActions(obj: Json): Json {
  * @param obj The FSM JSON object
  * @returns A new object with all string actions replaced by { type: string }
  */
-export function normalizeActionsToObjects(obj: Json): Json {
-  const clone = JSON.parse(JSON.stringify(obj));
+export function normalizeActionsToObjects(
+  obj: FsmDraftStateNode,
+): FsmDraftStateNode {
+  const clone: FsmDraftStateNode = JSON.parse(JSON.stringify(obj));
 
-  function toActionObject(a: Json): Json {
+  function toActionObject(a: FsmDraftAction): ActionObject {
     return typeof a === "string" ? { type: a } : a;
   }
 
-  function normalizeActionArray(arr: Json[]): Json[] {
+  function normalizeActionArray(arr: FsmDraftAction[]): ActionObject[] {
     return arr.map(toActionObject);
   }
 
-  function visitState(state: Json) {
+  function visitState(state: FsmDraftStateNode) {
     if (Array.isArray(state.entry)) {
       state.entry = normalizeActionArray(state.entry);
     }
@@ -96,14 +139,11 @@ export function normalizeActionsToObjects(obj: Json): Json {
       state.initial.actions = normalizeActionArray(state.initial.actions);
     }
 
-    if (state.on && typeof state.on === "object") {
+    if (state.on) {
       for (const eventKey of Object.keys(state.on)) {
-        const transitions = state.on[eventKey];
-        if (Array.isArray(transitions)) {
-          for (const transition of transitions) {
-            if (Array.isArray(transition.actions)) {
-              transition.actions = normalizeActionArray(transition.actions);
-            }
+        for (const transition of state.on[eventKey]) {
+          if (Array.isArray(transition.actions)) {
+            transition.actions = normalizeActionArray(transition.actions);
           }
         }
       }
@@ -116,7 +156,7 @@ export function normalizeActionsToObjects(obj: Json): Json {
       }
     }
 
-    if (state.states && typeof state.states === "object") {
+    if (state.states) {
       for (const subKey of Object.keys(state.states)) {
         visitState(state.states[subKey]);
       }
@@ -134,21 +174,22 @@ export function normalizeActionsToObjects(obj: Json): Json {
  * @param obj The FSM JSON object
  * @returns A new object with actionName populated on matching entry/exit actions
  */
-export function addActionNameFromDelay(obj: Json): Json {
-  const clone = JSON.parse(JSON.stringify(obj));
+export function addActionNameFromDelay(
+  obj: FsmDraftStateNode,
+): FsmDraftStateNode {
+  const clone: FsmDraftStateNode = JSON.parse(JSON.stringify(obj));
 
   /** Collect full transition objects whose event contains "xstate.after." and have a delay key */
-  function getAfterTransitions(state: Json): Json[] {
-    const afterTransitions: Json[] = [];
+  function getAfterTransitions(
+    state: FsmDraftStateNode,
+  ): FsmDraftTransition[] {
+    const afterTransitions: FsmDraftTransition[] = [];
 
-    if (state.on && typeof state.on === "object") {
+    if (state.on) {
       for (const eventKey of Object.keys(state.on)) {
         if (eventKey.includes("xstate.after.")) {
-          const transitions = state.on[eventKey];
-          if (Array.isArray(transitions)) {
-            for (const t of transitions) {
-              if ("delay" in t) afterTransitions.push(t);
-            }
+          for (const t of state.on[eventKey]) {
+            if ("delay" in t) afterTransitions.push(t);
           }
         }
       }
@@ -170,9 +211,9 @@ export function addActionNameFromDelay(obj: Json): Json {
 
   /** Map each xstate.raise/xstate.cancel action to the next after-transition's delay value */
   function enrichActionArray(
-    actions: Json[],
-    afterTransitions: Json[],
-  ): Json[] {
+    actions: FsmDraftAction[],
+    afterTransitions: FsmDraftTransition[],
+  ): FsmDraftAction[] {
     let i = 0;
     return actions.map((a) => {
       if (
@@ -191,7 +232,7 @@ export function addActionNameFromDelay(obj: Json): Json {
     });
   }
 
-  function visitState(state: Json) {
+  function visitState(state: FsmDraftStateNode) {
     const afterTransitions = getAfterTransitions(state);
 
     if (Array.isArray(state.entry)) {
@@ -201,7 +242,7 @@ export function addActionNameFromDelay(obj: Json): Json {
       state.exit = enrichActionArray(state.exit, afterTransitions);
     }
 
-    if (state.states && typeof state.states === "object") {
+    if (state.states) {
       for (const subKey of Object.keys(state.states)) {
         visitState(state.states[subKey]);
       }
@@ -222,10 +263,10 @@ export function addActionNameFromDelay(obj: Json): Json {
  * @returns { fulljson, childActorsInfo }
  */
 export function addMissingFsmTypeToInvokeActors(
-  fsmJSON: Json,
+  fsmJSON: FsmDraftStateNode,
   parentFsmVersion: string,
 ): {
-  fulljson: Json;
+  fulljson: FsmDraftStateNode;
   childActorsInfo: Array<
     {
       child_actor_src: string;
@@ -235,7 +276,7 @@ export function addMissingFsmTypeToInvokeActors(
     }
   >;
 } {
-  const clone = JSON.parse(JSON.stringify(fsmJSON));
+  const clone: FsmDraftStateNode = JSON.parse(JSON.stringify(fsmJSON));
   const childActorsInfo: Array<
     {
       child_actor_src: string;
@@ -245,34 +286,34 @@ export function addMissingFsmTypeToInvokeActors(
     }
   > = [];
 
-  function visitState(state: Json) {
+  function fillInvokeDefaults(invokeObj: FsmDraftInvoke) {
+    if (!("fsmType" in invokeObj)) {
+      invokeObj.fsmType = "promise";
+    }
+    if (!("fsmVersion" in invokeObj)) {
+      invokeObj.fsmVersion = parentFsmVersion;
+    }
+    if (!("fsmLanguage" in invokeObj)) {
+      invokeObj.fsmLanguage = "typescript";
+    }
+    if (invokeObj.src) {
+      childActorsInfo.push({
+        child_actor_src: invokeObj.src,
+        child_actor_fsmType: invokeObj.fsmType ?? "promise",
+        child_actor_fsmVersion: invokeObj.fsmVersion ?? parentFsmVersion,
+        child_actor_fsmLanguage: invokeObj.fsmLanguage ?? "typescript",
+      });
+    }
+  }
+
+  function visitState(state: FsmDraftStateNode) {
     if (Array.isArray(state.invoke)) {
       for (const invokeObj of state.invoke) {
-        // Only process if src exists
-        if (invokeObj && typeof invokeObj.src === "string") {
-          // Add missing fsmType
-          if (!("fsmType" in invokeObj)) {
-            invokeObj.fsmType = "promise";
-          }
-          // Add missing fsmVersion
-          if (!("fsmVersion" in invokeObj)) {
-            invokeObj.fsmVersion = parentFsmVersion;
-          }
-          // Add missing fsmLanguage (defaults to typescript)
-          if (!("fsmLanguage" in invokeObj)) {
-            invokeObj.fsmLanguage = "typescript";
-          }
-          childActorsInfo.push({
-            child_actor_src: invokeObj.src,
-            child_actor_fsmType: invokeObj.fsmType,
-            child_actor_fsmVersion: invokeObj.fsmVersion,
-            child_actor_fsmLanguage: invokeObj.fsmLanguage,
-          });
-        }
+        if (invokeObj.src) fillInvokeDefaults(invokeObj);
       }
     }
     // Recursively visit substates
-    if (state.states && typeof state.states === "object") {
+    if (state.states) {
       for (const subKey of Object.keys(state.states)) {
         visitState(state.states[subKey]);
       }
@@ -280,7 +321,7 @@ export function addMissingFsmTypeToInvokeActors(
   }
 
   // Visit all states recursively
-  if (clone.states && typeof clone.states === "object") {
+  if (clone.states) {
     for (const stateKey of Object.keys(clone.states)) {
       visitState(clone.states[stateKey]);
     }
@@ -289,23 +330,7 @@ export function addMissingFsmTypeToInvokeActors(
   // Also check root-level invoke (rare, but possible)
   if (Array.isArray(clone.invoke)) {
     for (const invokeObj of clone.invoke) {
-      if (invokeObj && typeof invokeObj.src === "string") {
-        if (!("fsmType" in invokeObj)) {
-          invokeObj.fsmType = "promise";
-        }
-        if (!("fsmVersion" in invokeObj)) {
-          invokeObj.fsmVersion = parentFsmVersion;
-        }
-        if (!("fsmLanguage" in invokeObj)) {
-          invokeObj.fsmLanguage = "typescript";
-        }
-        childActorsInfo.push({
-          child_actor_src: invokeObj.src,
-          child_actor_fsmType: invokeObj.fsmType,
-          child_actor_fsmVersion: invokeObj.fsmVersion,
-          child_actor_fsmLanguage: invokeObj.fsmLanguage,
-        });
-      }
+      if (invokeObj.src) fillInvokeDefaults(invokeObj);
     }
   }
 
@@ -341,7 +366,7 @@ export async function generateFsmJSONFromMachineFile(
       typeof machineConfig.toJSON === "function"
     ) {
       // step 1 — export raw XState JSON and write xstate-fsm.json
-      const xstateFsmJSON = machineConfig.toJSON();
+      const xstateFsmJSON: AnyStateNodeDefinition = machineConfig.toJSON();
       writeFileSync(
         `${absFolderPath}/xstate-fsm.json`,
         JSON.stringify(xstateFsmJSON, null, 2),

--- a/packages/fsm-compiler-ts/src/generated/fsm-machine-schema.types.ts
+++ b/packages/fsm-compiler-ts/src/generated/fsm-machine-schema.types.ts
@@ -1,0 +1,151 @@
+/**
+ * AUTO-GENERATED — do not edit by hand.
+ * Source: packages/database-src/fsm.machine.schema.v3.json
+ * Regenerate with: deno task generate:fsm-types (run from packages/fsm-compiler-ts)
+ */
+
+export type ID = string;
+export type AtomicStateNode = BaseStateNode & {
+  type?: "atomic";
+  entry?: ActionObject[];
+  exit?: ActionObject[];
+  invoke?: InvokeArray;
+  on: TransitionsObject;
+};
+export type Order = number;
+export type InvokeArray = InvokeObject[];
+export type CompoundStateNode = BaseStateNode & {
+  type?: "compound";
+  entry?: ActionObject[];
+  exit?: ActionObject[];
+  initial?: InitialTransitionObject;
+  invoke?: InvokeArray;
+  on?: TransitionsObject;
+  states: StatesObject;
+};
+export type ParallelStateNode = BaseStateNode & {
+  type?: "parallel";
+  entry?: ActionObject[];
+  exit?: ActionObject[];
+  invoke?: InvokeArray;
+  on?: TransitionsObject;
+  states: StatesObject;
+};
+export type HistoryStateNode = BaseStateNode & {
+  type?: "history";
+  history: "shallow" | "deep";
+};
+export type FinalStateNode = BaseStateNode & {
+  type?: "final";
+  data?: {
+    [k: string]: unknown;
+  };
+};
+
+export interface FsmMachineJson {
+  id: ID;
+  initial?: InitialTransitionObject;
+  key: string;
+  type: "compound" | "parallel";
+  context?: {
+    [k: string]: unknown;
+  };
+  states: StatesObject;
+  on?: TransitionsObject;
+  transitions?: TransitionObject[];
+  entry?: ActionObject[];
+  exit?: ActionObject[];
+  order?: Order;
+  invoke?: InvokeArray;
+  version?: string;
+}
+export interface InitialTransitionObject {
+  actions: ActionObject[];
+  source: string;
+  /**
+   * @minItems 1
+   */
+  target: [string, ...string[]];
+  eventType?: string | null;
+}
+export interface ActionObject {
+  /**
+   * The action type
+   */
+  type: string;
+  /**
+   * Required when type is xstate.raise or xstate.cancel
+   */
+  delayActionName?: string;
+  /**
+   * The event type for the delay action
+   */
+  delayActionEventType?: string;
+  [k: string]: unknown;
+}
+export interface StatesObject {
+  /**
+   * This interface was referenced by `StatesObject`'s JSON-Schema definition
+   * via the `patternProperty` "^.*$".
+   */
+  [k: string]:
+    | AtomicStateNode
+    | CompoundStateNode
+    | ParallelStateNode
+    | HistoryStateNode
+    | FinalStateNode;
+}
+export interface BaseStateNode {
+  id: string;
+  key: string;
+  type: "atomic" | "compound" | "parallel" | "final" | "history";
+  order?: Order;
+  /**
+   * The description of the state node, in Markdown
+   */
+  description?: string;
+}
+export interface InvokeObject {
+  type: string;
+  id: string;
+  src: string;
+  /**
+   * The type of the invoked service. promise for a new promise, sharedPromise for an existing promise but shared with other FSMs, and fsm for another finite state machine.
+   */
+  fsmType: "promise" | "sharedPromise" | "sharedFsm" | "fsm";
+  /**
+   * The version of the FSM being invoked, required if fsmType is fsm or sharedPromise
+   */
+  fsmVersion: string;
+  /**
+   * Language runtime that executes the invoked service. Defaults to typescript. Aligns with the actor folder convention (typescript/, python/, rust/, go/, llm/).
+   */
+  fsmLanguage?: "typescript" | "python" | "rust" | "go" | "llm";
+}
+export interface TransitionsObject {
+  /**
+   * This interface was referenced by `TransitionsObject`'s JSON-Schema definition
+   * via the `patternProperty` "^.*$".
+   */
+  [k: string]: TransitionObject[];
+}
+export interface TransitionObject {
+  actions: ActionObject[];
+  /**
+   * Legacy guard payload consumed by the PostgreSQL extension's transition loader (transition->'cond'). Not emitted by this compiler, which emits `guard` instead.
+   */
+  cond?: {
+    [k: string]: unknown;
+  };
+  /**
+   * Name of the guard function to evaluate for this transition.
+   */
+  guard?: string;
+  /**
+   * Delay identifier (xstate.after.* transitions) or duration in ms.
+   */
+  delay?: string | number;
+  eventType: string;
+  source: string;
+  target: string[];
+}

--- a/packages/fsm-compiler-ts/src/index-test.ts
+++ b/packages/fsm-compiler-ts/src/index-test.ts
@@ -26,7 +26,7 @@ import {
 const logger = getLogger(["@pgfsm/compiler", "test"]);
 await configureCompilerLogger();
 
-(async () => {
+(() => {
   logger.info("=== index.ts exports ===");
 
   const exports = {

--- a/packages/fsm-compiler-ts/src/index.ts
+++ b/packages/fsm-compiler-ts/src/index.ts
@@ -35,10 +35,8 @@ export {
 export type {
   ActorPluginValidationResult,
   ActorReference,
-  ExternalActor,
   FailedMethod,
   FsmPluginValidationResult,
-  InternalActor,
 } from "./util.ts";
 export type { WorkflowType } from "./util.ts";
 export {

--- a/packages/fsm-compiler-ts/src/load-fsm-json.ts
+++ b/packages/fsm-compiler-ts/src/load-fsm-json.ts
@@ -1,17 +1,16 @@
 import { getLogger } from "@logtape/logtape";
-import { v4 as uuidv4 } from "uuid";
-import { writeFileSync } from "node:fs";
 
 const logger = getLogger(["@pgfsm/compiler", "load"]);
 import { isVersionFolderName, type WorkflowType } from "./util.ts";
 import { type DBDeps, loadFsmFromJson } from "@pgfsm/db";
+import type { Json } from "@pgfsm/db/database.types";
 
 async function loadFsmJSONFromFolder(
   dirEntryName: string,
   dirEntryNameVersion: string,
-  folderPath: string,
+  _folderPath: string,
   absFolderPath: string,
-  parentSource: string,
+  _parentSource: string,
   workflowType: WorkflowType,
   deps: DBDeps,
 ) {
@@ -62,7 +61,7 @@ export async function loadFsmJSONFromFolders(
   workflowType: WorkflowType,
   skipDirs: string[] = [],
   deps: DBDeps,
-): Promise<any[]> {
+): Promise<Json[]> {
   if (folderPath.startsWith(".")) {
     throw new Error(
       `Invalid folder path: ${folderPath}. Folder paths cannot start with '.'`,
@@ -86,7 +85,7 @@ export async function loadFsmJSONFromFolders(
   const absFolderPath = folderPath.startsWith("/")
     ? folderPath
     : `${Deno.cwd()}/${folderPath}`;
-  const folderResults: any[] = [];
+  const folderResults: Json[] = [];
   for await (const dirEntry of Deno.readDir(absFolderPath)) {
     if (dirEntry.isDirectory) {
       if (skipDirs.includes(dirEntry.name)) {

--- a/packages/fsm-compiler-ts/src/load-fsm-json.ts
+++ b/packages/fsm-compiler-ts/src/load-fsm-json.ts
@@ -4,6 +4,7 @@ const logger = getLogger(["@pgfsm/compiler", "load"]);
 import { isVersionFolderName, type WorkflowType } from "./util.ts";
 import { type DBDeps, loadFsmFromJson } from "@pgfsm/db";
 import type { Json } from "@pgfsm/db/database.types";
+import type { FsmMachineJson } from "./generated/fsm-machine-schema.types.ts";
 
 async function loadFsmJSONFromFolder(
   dirEntryName: string,
@@ -18,7 +19,9 @@ async function loadFsmJSONFromFolder(
   try {
     await Deno.stat(fsmJson);
     // 1. Load fsm.json file
-    const fsmData = JSON.parse(await Deno.readTextFile(fsmJson));
+    const fsmData: FsmMachineJson = JSON.parse(
+      await Deno.readTextFile(fsmJson),
+    );
 
     // 2. Process fsmData and insert into database using helper functions
     // Call loadFsmStateFromJsonV2 and loadFsmTransitionFromJsonV2 with fsmData

--- a/packages/fsm-compiler-ts/src/operation-logic-scaffold.ts
+++ b/packages/fsm-compiler-ts/src/operation-logic-scaffold.ts
@@ -4,6 +4,7 @@ import {
   DELAY_ACTION_NAME_PREFIX,
   isVersionFolderName,
 } from "./util.ts";
+import type { FsmMachineJson } from "./generated/fsm-machine-schema.types.ts";
 
 const logger = getLogger(["@pgfsm/compiler", "scaffold"]);
 
@@ -178,7 +179,7 @@ export async function writeActorFile(
 export async function eachVersionedFsmFolder(
   folderPath: string,
   skipDirs: string[],
-  handler: (absFolderPath: string, fsmData: unknown) => Promise<void>,
+  handler: (absFolderPath: string, fsmData: FsmMachineJson) => Promise<void>,
 ): Promise<void> {
   if (folderPath.startsWith(".")) {
     throw new Error(
@@ -212,7 +213,9 @@ export async function eachVersionedFsmFolder(
       const versionFolderPath = `${fsmDirPath}/${subEntry.name}`;
       const fsmJsonPath = `${versionFolderPath}/fsm.json`;
       try {
-        const fsmData = JSON.parse(await Deno.readTextFile(fsmJsonPath));
+        const fsmData: FsmMachineJson = JSON.parse(
+          await Deno.readTextFile(fsmJsonPath),
+        );
         await handler(versionFolderPath, fsmData);
       } catch (err) {
         if (err instanceof Deno.errors.NotFound) {

--- a/packages/fsm-compiler-ts/src/util.ts
+++ b/packages/fsm-compiler-ts/src/util.ts
@@ -1,3 +1,5 @@
+import type { Json } from "@pgfsm/db/database.types";
+
 export type WorkflowType = "fsm" | "sharedFsm" | "sharedPromise" | "promise";
 
 export type ActorReference = {
@@ -39,13 +41,13 @@ export type FsmPluginValidationResult = {
   fsmParentDirName: string;
   fsmParentAbsFolderPath: string;
   fsmParentRelativeFolderPath: string;
-  fsmJsonConfigData: any;
+  fsmJsonConfigData: Json;
   fsmJsonPresent: boolean;
   fsmJsonFollowSchema: boolean;
   isFsmModuleVerified: boolean;
-  fsmModuleDefinition: any;
+  fsmModuleDefinition: Json;
   failedMethods: FailedMethod[];
-  asyncOperationActors: any[];
+  asyncOperationActors: ActorReference[];
   isAsyncOperationActorsVerified?: boolean;
 };
 
@@ -67,14 +69,17 @@ export type ActorPluginValidationResult = {
 
 export const DELAY_ACTION_NAME_PREFIX = "delay";
 
-export const RAISE_CANCEL = new Set(["xstate.raise", "xstate.cancel"]);
+export const RAISE_CANCEL: Set<string> = new Set([
+  "xstate.raise",
+  "xstate.cancel",
+]);
 
 /**
  * Recursively traverses FSM JSON and collects all action, guard, delay, and actor names.
  * Actors are returned as objects preserving fsmType, fsmVersion, and fsmLanguage
  * (fsmLanguage defaults to "typescript" when absent on the invoke object).
  */
-export function extractFsmPluginRefs(fsmData: any): {
+export function extractFsmPluginRefs(fsmData: Json): {
   actions: string[];
   guards: string[];
   delays: string[];
@@ -85,14 +90,14 @@ export function extractFsmPluginRefs(fsmData: any): {
   const delaysSet = new Set<string>();
   const actorsArr: ActorReference[] = [];
 
-  function collectActionName(a: any) {
+  function collectActionName(a: Json) {
     if (typeof a === "string") actionsSet.add(a);
     else if (a && typeof a === "object" && typeof a.type === "string") {
       actionsSet.add(a.type);
     }
   }
 
-  function visitState(state: any) {
+  function visitState(state: Json) {
     if (Array.isArray(state.entry)) state.entry.forEach(collectActionName);
     if (Array.isArray(state.exit)) state.exit.forEach(collectActionName);
 
@@ -206,7 +211,7 @@ export function isTimestampFolderName(name: string): boolean {
 /**
  * Recursively replaces underscores with spaces in keys and string values of an object.
  */
-export function replaceUnderscoresWithSpaces(objWithMachine: any): any {
+export function replaceUnderscoresWithSpaces(objWithMachine: Json): Json {
   const obj = objWithMachine?.machine ? objWithMachine.machine : objWithMachine;
   if (Array.isArray(obj)) {
     return obj.map(replaceUnderscoresWithSpaces);
@@ -215,7 +220,7 @@ export function replaceUnderscoresWithSpaces(objWithMachine: any): any {
       const newKey = typeof key === "string" ? key.replace(/_/g, " ") : key;
       acc[newKey] = replaceUnderscoresWithSpaces(value);
       return acc;
-    }, {} as any);
+    }, {} as Json);
   } else if (typeof obj === "string") {
     return obj.replace(/_/g, " ");
   } else {
@@ -226,7 +231,7 @@ export function replaceUnderscoresWithSpaces(objWithMachine: any): any {
 /**
  * Recursively replaces spaces with underscores in keys and string values of an object.
  */
-export function replaceSpacesWithUnderscores(obj: any): any {
+export function replaceSpacesWithUnderscores(obj: Json): Json {
   if (Array.isArray(obj)) {
     return obj.map(replaceSpacesWithUnderscores);
   } else if (obj && typeof obj === "object") {
@@ -234,7 +239,7 @@ export function replaceSpacesWithUnderscores(obj: any): any {
       const newKey = typeof key === "string" ? key.replace(/ /g, "_") : key;
       acc[newKey] = replaceSpacesWithUnderscores(value);
       return acc;
-    }, {} as any);
+    }, {} as Json);
   } else if (typeof obj === "string") {
     return obj.replace(/ /g, "_");
   } else {

--- a/packages/fsm-compiler-ts/src/util.ts
+++ b/packages/fsm-compiler-ts/src/util.ts
@@ -23,23 +23,6 @@ export type FailedMethod = {
   modulePath: string;
 };
 
-export type InternalActor = {
-  src: string;
-  fsmName: string;
-  fsmType?: string;
-  fsmVersion?: string;
-  fsmAbsFolderPath: string;
-  fsmRelativeFolderPath: string;
-  resolved: boolean;
-};
-
-export type ExternalActor = {
-  src: string;
-  fsmType?: string;
-  fsmVersion?: string;
-  resolved: boolean;
-};
-
 export type FsmPluginValidationResult = {
   src: string;
   fsmName: string;

--- a/packages/fsm-compiler-ts/src/util.ts
+++ b/packages/fsm-compiler-ts/src/util.ts
@@ -1,4 +1,13 @@
 import type { Json } from "@pgfsm/db/database.types";
+import type {
+  ActionObject,
+  AtomicStateNode,
+  CompoundStateNode,
+  FinalStateNode,
+  FsmMachineJson,
+  HistoryStateNode,
+  ParallelStateNode,
+} from "./generated/fsm-machine-schema.types.ts";
 
 export type WorkflowType = "fsm" | "sharedFsm" | "sharedPromise" | "promise";
 
@@ -41,7 +50,7 @@ export type FsmPluginValidationResult = {
   fsmParentDirName: string;
   fsmParentAbsFolderPath: string;
   fsmParentRelativeFolderPath: string;
-  fsmJsonConfigData: Json;
+  fsmJsonConfigData: FsmMachineJson | undefined;
   fsmJsonPresent: boolean;
   fsmJsonFollowSchema: boolean;
   isFsmModuleVerified: boolean;
@@ -74,12 +83,20 @@ export const RAISE_CANCEL: Set<string> = new Set([
   "xstate.cancel",
 ]);
 
+type FsmStateOrMachine =
+  | FsmMachineJson
+  | AtomicStateNode
+  | CompoundStateNode
+  | ParallelStateNode
+  | HistoryStateNode
+  | FinalStateNode;
+
 /**
  * Recursively traverses FSM JSON and collects all action, guard, delay, and actor names.
  * Actors are returned as objects preserving fsmType, fsmVersion, and fsmLanguage
  * (fsmLanguage defaults to "typescript" when absent on the invoke object).
  */
-export function extractFsmPluginRefs(fsmData: Json): {
+export function extractFsmPluginRefs(fsmData: FsmMachineJson): {
   actions: string[];
   guards: string[];
   delays: string[];
@@ -90,62 +107,58 @@ export function extractFsmPluginRefs(fsmData: Json): {
   const delaysSet = new Set<string>();
   const actorsArr: ActorReference[] = [];
 
-  function collectActionName(a: Json) {
-    if (typeof a === "string") actionsSet.add(a);
-    else if (a && typeof a === "object" && typeof a.type === "string") {
-      actionsSet.add(a.type);
-    }
+  // Not every fsm.json on disk has necessarily been regenerated with the
+  // current compiler (which always emits actionObjects); tolerate the older
+  // plain-string action shorthand defensively.
+  function collectActionName(a: ActionObject) {
+    const value: unknown = a;
+    if (typeof value === "string") actionsSet.add(value);
+    else if (a && typeof a.type === "string") actionsSet.add(a.type);
   }
 
-  function visitState(state: Json) {
-    if (Array.isArray(state.entry)) state.entry.forEach(collectActionName);
-    if (Array.isArray(state.exit)) state.exit.forEach(collectActionName);
+  function visitState(state: FsmStateOrMachine) {
+    if ("entry" in state && Array.isArray(state.entry)) {
+      state.entry.forEach(collectActionName);
+    }
+    if ("exit" in state && Array.isArray(state.exit)) {
+      state.exit.forEach(collectActionName);
+    }
 
-    if (state.on && typeof state.on === "object") {
+    if ("on" in state && state.on) {
       for (const eventKey of Object.keys(state.on)) {
         const transitions = state.on[eventKey];
-        if (Array.isArray(transitions)) {
-          for (const transition of transitions) {
-            if (Array.isArray(transition.actions)) {
-              transition.actions.forEach(collectActionName);
-            }
-            if (transition.guard && typeof transition.guard === "string") {
-              guardsSet.add(transition.guard);
-            }
-            if (transition.delay) delaysSet.add(transition.delay);
+        for (const transition of transitions) {
+          transition.actions.forEach(collectActionName);
+          if (transition.guard) guardsSet.add(transition.guard);
+          if (transition.delay !== undefined) {
+            delaysSet.add(String(transition.delay));
           }
         }
       }
     }
 
-    if (Array.isArray(state.transitions)) {
+    if ("transitions" in state && state.transitions) {
       for (const transition of state.transitions) {
-        if (Array.isArray(transition.actions)) {
-          transition.actions.forEach(collectActionName);
+        transition.actions.forEach(collectActionName);
+        if (transition.guard) guardsSet.add(transition.guard);
+        if (transition.delay !== undefined) {
+          delaysSet.add(String(transition.delay));
         }
-        if (transition.guard && typeof transition.guard === "string") {
-          guardsSet.add(transition.guard);
-        }
-        if (transition.delay) delaysSet.add(transition.delay);
       }
     }
 
-    if (Array.isArray(state.invoke)) {
+    if ("invoke" in state && state.invoke) {
       for (const inv of state.invoke) {
-        if (inv && typeof inv.src === "string") {
-          actorsArr.push({
-            src: inv.src,
-            fsmType: inv.fsmType,
-            fsmVersion: inv.fsmVersion,
-            fsmLanguage: typeof inv.fsmLanguage === "string"
-              ? inv.fsmLanguage
-              : "typescript",
-          });
-        }
+        actorsArr.push({
+          src: inv.src,
+          fsmType: inv.fsmType,
+          fsmVersion: inv.fsmVersion,
+          fsmLanguage: inv.fsmLanguage ?? "typescript",
+        });
       }
     }
 
-    if (state.states && typeof state.states === "object") {
+    if ("states" in state && state.states) {
       for (const subKey of Object.keys(state.states)) {
         visitState(state.states[subKey]);
       }

--- a/packages/fsm-compiler-ts/src/validate-async-operation-logic-v2.ts
+++ b/packages/fsm-compiler-ts/src/validate-async-operation-logic-v2.ts
@@ -20,9 +20,9 @@ import {
 
 export async function validateAsyncOperationFromFoldersV2(
   folderPath: string,
-  workflowType: WorkflowType,
+  _workflowType: WorkflowType,
   skipDirs: string[] = [],
-  availableActors: ActorReference[] = [],
+  _availableActors: ActorReference[] = [],
   runtimeLanguages: OperationLang[] = [],
 ): Promise<ActorPluginValidationResult[]> {
   if (folderPath.startsWith(".")) {

--- a/packages/fsm-compiler-ts/src/validate-sync-operation-logic.ts
+++ b/packages/fsm-compiler-ts/src/validate-sync-operation-logic.ts
@@ -10,18 +10,18 @@ import machineSchema from "../../database-src/fsm.machine.schema.v3.json" with {
 import {
   type ActorReference,
   DELAY_ACTION_NAME_PREFIX,
-  type ExternalActor,
   extractFsmPluginRefs,
   type FailedMethod,
   type FsmPluginValidationResult,
-  type InternalActor,
   isVersionFolderName,
   RAISE_CANCEL,
   type WorkflowType,
 } from "./util.ts";
 import type { Json } from "@pgfsm/db/database.types";
 
-export const isFunction = (v: unknown): v is Function =>
+type AnyFunction = (...args: unknown[]) => unknown;
+
+export const isFunction = (v: unknown): v is AnyFunction =>
   typeof v === "function";
 
 export const hasArity = (n: number) => (fn: unknown): boolean =>
@@ -33,7 +33,7 @@ export async function validateLanguageModules(
   actions: string[],
   guards: string[],
   delays: string[],
-) {
+): Promise<{ modules: Record<string, Json>; failedMethods: FailedMethod[] }> {
   const failedMethods: FailedMethod[] = [];
 
   const filteredActions = actions.filter((a) => !RAISE_CANCEL.has(a));
@@ -44,7 +44,7 @@ export async function validateLanguageModules(
     { type: "delays", names: prefixedDelays },
   ];
 
-  const modules: Record<string, any> = {
+  const modules: Record<string, Json> = {
     actions: null,
     guards: null,
     delays: null,
@@ -107,18 +107,18 @@ export async function validateSyncOperationFromFolder(
   parentAbsPath: string,
   parentRelPath: string,
   workflowType: WorkflowType,
-  availableActors: ActorReference[],
+  _availableActors: ActorReference[],
 ): Promise<FsmPluginValidationResult> {
-  let fsmJsonPresent = true;
-  let fsmJsonConfigData: any = undefined;
+  const fsmJsonPresent = true;
+  const fsmJsonConfigData: Json = undefined;
   let fsmJsonFollowSchema = false;
-  let fsmModuleDefinition: any = undefined;
+  let fsmModuleDefinition: Json = undefined;
   let isFsmModuleVerified = false;
   let failedMethods: FailedMethod[] = [];
   let actions: string[] = [];
   let guards: string[] = [];
   let delays: string[] = [];
-  let asyncOperationActors: any[] = [];
+  let asyncOperationActors: ActorReference[] = [];
 
   const ajv = new Ajv({ allErrors: true, strict: true, verbose: true });
   const validate = ajv.compile(machineSchema);

--- a/packages/fsm-compiler-ts/src/validate-sync-operation-logic.ts
+++ b/packages/fsm-compiler-ts/src/validate-sync-operation-logic.ts
@@ -18,6 +18,7 @@ import {
   type WorkflowType,
 } from "./util.ts";
 import type { Json } from "@pgfsm/db/database.types";
+import type { FsmMachineJson } from "./generated/fsm-machine-schema.types.ts";
 
 type AnyFunction = (...args: unknown[]) => unknown;
 
@@ -98,7 +99,7 @@ export async function validateLanguageModules(
 }
 
 export async function validateSyncOperationFromFolder(
-  fsmData: Json,
+  fsmData: FsmMachineJson,
   dirName: string,
   versionName: string,
   absPath: string,
@@ -110,7 +111,7 @@ export async function validateSyncOperationFromFolder(
   _availableActors: ActorReference[],
 ): Promise<FsmPluginValidationResult> {
   const fsmJsonPresent = true;
-  const fsmJsonConfigData: Json = undefined;
+  const fsmJsonConfigData: FsmMachineJson | undefined = undefined;
   let fsmJsonFollowSchema = false;
   let fsmModuleDefinition: Json = undefined;
   let isFsmModuleVerified = false;

--- a/packages/fsm-compiler-ts/test/generate-fsm-json.test.ts
+++ b/packages/fsm-compiler-ts/test/generate-fsm-json.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import {
   addMissingFsmTypeToInvokeActors,
+  type FsmDraftStateNode,
   generateFsmJSONFromFolders,
   normalizeActionsToObjects,
 } from "../src/generate-fsm-json.ts";
@@ -8,7 +9,7 @@ import {
 // --- addMissingFsmTypeToInvokeActors unit tests ---
 
 Deno.test("addMissingFsmTypeToInvokeActors - adds missing fsmType and fsmVersion", () => {
-  const fsmJSON = {
+  const fsmJSON: FsmDraftStateNode = {
     states: {
       idle: {
         invoke: [{ src: "someActor" }],
@@ -20,9 +21,9 @@ Deno.test("addMissingFsmTypeToInvokeActors - adds missing fsmType and fsmVersion
     "v01",
   );
 
-  assertEquals(fulljson.states.idle.invoke[0].fsmType, "promise");
-  assertEquals(fulljson.states.idle.invoke[0].fsmVersion, "v01");
-  assertEquals(fulljson.states.idle.invoke[0].fsmLanguage, "typescript");
+  assertEquals(fulljson.states!.idle.invoke![0].fsmType, "promise");
+  assertEquals(fulljson.states!.idle.invoke![0].fsmVersion, "v01");
+  assertEquals(fulljson.states!.idle.invoke![0].fsmLanguage, "typescript");
   assertEquals(childActorsInfo.length, 1);
   assertEquals(childActorsInfo[0].child_actor_src, "someActor");
   assertEquals(childActorsInfo[0].child_actor_fsmType, "promise");
@@ -31,7 +32,7 @@ Deno.test("addMissingFsmTypeToInvokeActors - adds missing fsmType and fsmVersion
 });
 
 Deno.test("addMissingFsmTypeToInvokeActors - preserves existing fsmType and fsmVersion", () => {
-  const fsmJSON = {
+  const fsmJSON: FsmDraftStateNode = {
     states: {
       idle: {
         invoke: [{
@@ -48,16 +49,16 @@ Deno.test("addMissingFsmTypeToInvokeActors - preserves existing fsmType and fsmV
     "v01",
   );
 
-  assertEquals(fulljson.states.idle.invoke[0].fsmType, "sharedFsm");
-  assertEquals(fulljson.states.idle.invoke[0].fsmVersion, "v02");
-  assertEquals(fulljson.states.idle.invoke[0].fsmLanguage, "python");
+  assertEquals(fulljson.states!.idle.invoke![0].fsmType, "sharedFsm");
+  assertEquals(fulljson.states!.idle.invoke![0].fsmVersion, "v02");
+  assertEquals(fulljson.states!.idle.invoke![0].fsmLanguage, "python");
   assertEquals(childActorsInfo[0].child_actor_fsmType, "sharedFsm");
   assertEquals(childActorsInfo[0].child_actor_fsmVersion, "v02");
   assertEquals(childActorsInfo[0].child_actor_fsmLanguage, "python");
 });
 
 Deno.test("addMissingFsmTypeToInvokeActors - handles nested states", () => {
-  const fsmJSON = {
+  const fsmJSON: FsmDraftStateNode = {
     states: {
       outer: {
         states: {
@@ -74,7 +75,7 @@ Deno.test("addMissingFsmTypeToInvokeActors - handles nested states", () => {
 });
 
 Deno.test("addMissingFsmTypeToInvokeActors - handles root-level invoke", () => {
-  const fsmJSON = {
+  const fsmJSON: FsmDraftStateNode = {
     invoke: [{ src: "rootActor" }],
     states: {},
   };
@@ -84,13 +85,13 @@ Deno.test("addMissingFsmTypeToInvokeActors - handles root-level invoke", () => {
 });
 
 Deno.test("addMissingFsmTypeToInvokeActors - returns empty childActorsInfo when no invoke", () => {
-  const fsmJSON = { states: { idle: {} } };
+  const fsmJSON: FsmDraftStateNode = { states: { idle: {} } };
   const { childActorsInfo } = addMissingFsmTypeToInvokeActors(fsmJSON, "v01");
   assertEquals(childActorsInfo.length, 0);
 });
 
 Deno.test("addMissingFsmTypeToInvokeActors - does not mutate original", () => {
-  const fsmJSON = {
+  const fsmJSON: FsmDraftStateNode = {
     states: { idle: { invoke: [{ src: "actor" }] } },
   };
   const original = JSON.stringify(fsmJSON);
@@ -101,7 +102,7 @@ Deno.test("addMissingFsmTypeToInvokeActors - does not mutate original", () => {
 // --- normalizeActionsToObjects unit tests ---
 
 Deno.test("normalizeActionsToObjects - converts string entry/exit actions to { type }", () => {
-  const input = {
+  const input: FsmDraftStateNode = {
     states: {
       idle: {
         entry: ["doEnter", "doAlso"],
@@ -110,14 +111,14 @@ Deno.test("normalizeActionsToObjects - converts string entry/exit actions to { t
     },
   };
   const result = normalizeActionsToObjects(input);
-  assertEquals(result.states.idle.entry, [{ type: "doEnter" }, {
+  assertEquals(result.states!.idle.entry, [{ type: "doEnter" }, {
     type: "doAlso",
   }]);
-  assertEquals(result.states.idle.exit, [{ type: "doExit" }]);
+  assertEquals(result.states!.idle.exit, [{ type: "doExit" }]);
 });
 
 Deno.test("normalizeActionsToObjects - converts string actions in on-transitions", () => {
-  const input = {
+  const input: FsmDraftStateNode = {
     states: {
       idle: {
         on: {
@@ -132,13 +133,14 @@ Deno.test("normalizeActionsToObjects - converts string actions in on-transitions
     },
   };
   const result = normalizeActionsToObjects(input);
-  assertEquals(result.states.idle.on.NEXT[0].actions, [{ type: "assignFoo" }, {
-    type: "assignBar",
-  }]);
+  assertEquals(
+    result.states!.idle.on!.NEXT[0].actions,
+    [{ type: "assignFoo" }, { type: "assignBar" }],
+  );
 });
 
 Deno.test("normalizeActionsToObjects - converts string actions in transitions array", () => {
-  const input = {
+  const input: FsmDraftStateNode = {
     states: {
       idle: {
         transitions: [{
@@ -151,22 +153,22 @@ Deno.test("normalizeActionsToObjects - converts string actions in transitions ar
     },
   };
   const result = normalizeActionsToObjects(input);
-  assertEquals(result.states.idle.transitions[0].actions, [{
+  assertEquals(result.states!.idle.transitions![0].actions, [{
     type: "doSomething",
   }]);
 });
 
 Deno.test("normalizeActionsToObjects - converts string actions in initial transition", () => {
-  const input = {
+  const input: FsmDraftStateNode = {
     initial: { actions: ["initAction"], source: "root", target: ["idle"] },
     states: { idle: {} },
   };
   const result = normalizeActionsToObjects(input);
-  assertEquals(result.initial.actions, [{ type: "initAction" }]);
+  assertEquals(result.initial!.actions, [{ type: "initAction" }]);
 });
 
 Deno.test("normalizeActionsToObjects - leaves existing actionObjects unchanged", () => {
-  const input = {
+  const input: FsmDraftStateNode = {
     states: {
       idle: {
         entry: [{ type: "alreadyObject", extra: true }],
@@ -174,14 +176,14 @@ Deno.test("normalizeActionsToObjects - leaves existing actionObjects unchanged",
     },
   };
   const result = normalizeActionsToObjects(input);
-  assertEquals(result.states.idle.entry, [{
+  assertEquals(result.states!.idle.entry, [{
     type: "alreadyObject",
     extra: true,
   }]);
 });
 
 Deno.test("normalizeActionsToObjects - handles nested states recursively", () => {
-  const input = {
+  const input: FsmDraftStateNode = {
     states: {
       outer: {
         states: {
@@ -193,13 +195,13 @@ Deno.test("normalizeActionsToObjects - handles nested states recursively", () =>
     },
   };
   const result = normalizeActionsToObjects(input);
-  assertEquals(result.states.outer.states.inner.entry, [{
+  assertEquals(result.states!.outer.states!.inner.entry, [{
     type: "nestedAction",
   }]);
 });
 
 Deno.test("normalizeActionsToObjects - does not mutate original", () => {
-  const input = {
+  const input: FsmDraftStateNode = {
     states: { idle: { entry: ["doEnter"] } },
   };
   const original = JSON.stringify(input);

--- a/packages/fsm-compiler-ts/test/util.test.ts
+++ b/packages/fsm-compiler-ts/test/util.test.ts
@@ -5,11 +5,31 @@ import {
   isValidDateFolderName,
   isVersionFolderName,
 } from "../src/util.ts";
+import type { FsmMachineJson } from "../src/generated/fsm-machine-schema.types.ts";
+
+// Minimal fixtures — only `states` matters for extractFsmPluginRefs, but the
+// full FsmMachineJson contract (matching what real callers always have) is
+// enforced at the type level, so the required id/key/type fields are filled
+// in with placeholders here.
+const baseFsm = { id: "root", key: "root", type: "compound" as const };
+
+const baseInvoke = {
+  type: "xstate.invoke",
+  id: "0.idle",
+  fsmType: "promise" as const,
+  fsmVersion: "v01",
+};
+const baseState = { id: "root.idle", key: "idle", type: "atomic" as const };
 
 Deno.test("extractFsmPluginRefs - defaults actor fsmLanguage to typescript", () => {
-  const fsmData = {
+  const fsmData: FsmMachineJson = {
+    ...baseFsm,
     states: {
-      idle: { invoke: [{ src: "someActor" }] },
+      idle: {
+        ...baseState,
+        invoke: [{ ...baseInvoke, src: "someActor" }],
+        on: {},
+      },
     },
   };
   const { actors } = extractFsmPluginRefs(fsmData);
@@ -19,9 +39,14 @@ Deno.test("extractFsmPluginRefs - defaults actor fsmLanguage to typescript", () 
 });
 
 Deno.test("extractFsmPluginRefs - preserves explicit actor fsmLanguage", () => {
-  const fsmData = {
+  const fsmData: FsmMachineJson = {
+    ...baseFsm,
     states: {
-      idle: { invoke: [{ src: "pyActor", fsmLanguage: "python" }] },
+      idle: {
+        ...baseState,
+        invoke: [{ ...baseInvoke, src: "pyActor", fsmLanguage: "python" }],
+        on: {},
+      },
     },
   };
   const { actors } = extractFsmPluginRefs(fsmData);

--- a/packages/fsm-compiler-ts/test/validate-fsm-plugin-load.test.ts
+++ b/packages/fsm-compiler-ts/test/validate-fsm-plugin-load.test.ts
@@ -4,6 +4,7 @@ import {
   isFunction,
   validateSyncOperationFromFolder,
 } from "../src/validate-sync-operation-logic.ts";
+import type { FsmMachineJson } from "../src/generated/fsm-machine-schema.types.ts";
 
 // isFunction
 Deno.test("isFunction - returns true for functions", () => {
@@ -47,7 +48,9 @@ Deno.test("hasArity - returns false for non-functions", () => {
 
 // validateSyncOperationFromFolder - early return on schema failure
 Deno.test("validateSyncOperationFromFolder - returns defaults when fsm.json fails schema", async () => {
-  const invalidFsmData = { not: "a valid fsm" };
+  // Intentionally malformed to exercise the AJV rejection path — cast past
+  // the compile-time contract since real callers always pass parsed JSON.
+  const invalidFsmData = { not: "a valid fsm" } as unknown as FsmMachineJson;
 
   const result = await validateSyncOperationFromFolder(
     invalidFsmData,


### PR DESCRIPTION
## Summary
Supersedes #40 (branch `chore/39-fix-compiler-ts-lint`). That PR fixed the same 61 lint errors but leaned on this repo's `Json` type, which is effectively `any` under the hood (`type Json = JsonGenerated | any`). This PR fixes the same lint errors by modeling the two real shapes the compiler pipeline actually handles instead:

- **Raw pre-compilation JSON** (`machineConfig.toJSON()`) is typed with XState 5's own `AnyStateNodeDefinition` — no need to reinvent a type XState already publishes.
- **Compiled FSM JSON** (`fsm.json`) is typed via `FsmMachineJson`, generated from `packages/database-src/fsm.machine.schema.v3.json` by `json-schema-to-typescript` (new `deno task generate:fsm-types`), matching this repo's existing `supabase:gen:types` → `database.types.ts` pattern. Checked in at `src/generated/fsm-machine-schema.types.ts`; rerun the task after editing the schema.

I verified this approach directly before committing to it:
- A type-level derivation (`json-schema-to-ts`'s `FromSchema<>`) was tried first and **does not work** — the schema is genuinely recursive (states-within-states) and TS mapped-type inference can't resolve that cycle. `json-schema-to-typescript` (a different package) works because it emits real recursive `interface` declarations instead of computing a type.
- Ran the generator against the actual schema and hand-verified the output (recursion, discriminated unions, literal types) before wiring it in.
- Re-validated every real `fsm.json` fixture in `apps/fsm-core-example` against the tightened schema before and after each change to confirm no regressions.

## Schema fixes (surfaced by modeling the real shape)
- `pattern` used instead of `const` for state-node `type` discriminants — only unanchored-substring-matched at runtime (a real, if latent, validation gap) and produced widened `string` types instead of literals.
- `transitionObject` was missing `guard` (string) and `delay` (string | number) — fields the compiler actually emits — while declaring an object-shaped `cond` field that no real fsm.json in this repo has ever emitted (kept, since the PostgreSQL extension's transition loader still reads `transition->'cond'`).
- `initialTransitionObject` was missing `eventType`, present on every real fixture.
- Root `entry`/`exit` and three free-form object fields (`context`, `cond`, `data`) didn't reference `actionObject`/`additionalProperties`, producing bogus `{}` types (`ban-types`) instead of a real shape.

## Known pre-existing issue (not fixed here, flagged for follow-up)
`apps/fsm-core-example/sharedFSM/vitalsWorkflow/v02/fsm.json` fails schema validation independent of this PR — a `CheckVitals` state mistyped `"atomic"` that structurally looks like it should be `"parallel"` (has a 4-actor `invoke` array and malformed `initial`/`history` leftovers). Confirmed present on `main` before any of these changes, both against the original and tightened schema. Will file a separate bug issue.

## Test plan
- [x] `deno lint` — 0 problems, 28 files checked
- [x] `deno check` across `src/`, `test/`, and the generator script — passes (one pre-existing, unrelated `index-test.ts` import mismatch confirmed present on `main`, left untouched — out of scope)
- [x] `deno test` (run from repo root) — 51 passed / 8 failed, identical to the `main` baseline (the 8 failures are a stray `package.json` "overrides" warning polluting stderr capture in CLI subprocess tests, unrelated to typing/lint)
- [x] All 7 real `fsm.json` fixtures re-validated against the schema before/after — same 6/7 pass rate as `main` (the 1 failure is the pre-existing `vitalsWorkflow/v02` issue above)

Closes #39