### PR TITLE
chore(database): remove unused uuid import from fake-user scripts

### DIFF
--- a/packages/database-src/create-fake-user.ts
+++ b/packages/database-src/create-fake-user.ts
@@ -1,6 +1,5 @@
 import dotenv from "dotenv";
 import { createClient } from "@supabase/supabase-js";
-import { v4 as uuidv4 } from "uuid";
 
 dotenv.config({ path: "./../../.env" });
 

--- a/packages/database-src/delete-fake-user.ts
+++ b/packages/database-src/delete-fake-user.ts
@@ -1,6 +1,5 @@
 import dotenv from "dotenv";
 import { createClient } from "@supabase/supabase-js";
-import { v4 as uuidv4 } from "uuid";
 
 dotenv.config({ path: "./../../.env" });
 


### PR DESCRIPTION
## Summary
- Remove the unused `uuidv4` import from `uuid` in `create-fake-user.ts` and `delete-fake-user.ts` — neither script calls it.

Closes #43

## Test plan
- [x] `deno fmt` passes (pre-commit hook)
- [x] Confirmed `uuidv4` had no remaining references in either file