### PR TITLE
fix(logging): resolve deno lint errors in fsm-logging-ts

### DIFF
--- a/packages/fsm-logging-ts/src/configure.ts
+++ b/packages/fsm-logging-ts/src/configure.ts
@@ -1,4 +1,5 @@
 import { configure, type Sink } from "@logtape/logtape";
+// import { getConsoleSink } from "@logtape/logtape"; --- IGNORE ---
 import { getOpenTelemetrySink } from "@logtape/otel";
 import { getTableConsoleSink } from "./sink.ts";
 import type { LogLevel } from "./types.ts";
@@ -50,6 +51,7 @@ export async function configureLogging(
 
   const sinks: Record<string, Sink> = {
     console: getTableConsoleSink(),
+    // console: getConsoleSink(), --- IGNORE ---
     noop: () => {},
   };
   if (otelEnabled) sinks.otel = getOpenTelemetrySink();

--- a/packages/fsm-logging-ts/src/configure.ts
+++ b/packages/fsm-logging-ts/src/configure.ts
@@ -1,4 +1,4 @@
-import { configure, getConsoleSink, type Sink } from "@logtape/logtape";
+import { configure, type Sink } from "@logtape/logtape";
 import { getOpenTelemetrySink } from "@logtape/otel";
 import { getTableConsoleSink } from "./sink.ts";
 import type { LogLevel } from "./types.ts";
@@ -50,7 +50,6 @@ export async function configureLogging(
 
   const sinks: Record<string, Sink> = {
     console: getTableConsoleSink(),
-    // console: getConsoleSink(),
     noop: () => {},
   };
   if (otelEnabled) sinks.otel = getOpenTelemetrySink();

--- a/packages/fsm-logging-ts/src/sink.ts
+++ b/packages/fsm-logging-ts/src/sink.ts
@@ -10,7 +10,7 @@ import { isFlatObject, RENDER_KEY, type RenderPayload } from "./render.ts";
 // True when stdout is an interactive TTY (Deno first, Node fallback). Gates the
 // rich table/dir rendering below — those are for humans at a terminal; piped
 // output falls back to a single greppable line.
-export const isTerminal = typeof Deno !== "undefined"
+export const isTerminal: boolean = typeof Deno !== "undefined"
   ? Deno.stdout.isTerminal()
   : typeof process !== "undefined" && !!process.stdout?.isTTY;
 


### PR DESCRIPTION
## Summary
- Removed an unused `getConsoleSink` import and its dead commented-out reference in `configure.ts`, clearing `no-unused-vars` and `verbatim-module-syntax`
- Added an explicit `boolean` return type to the exported `isTerminal` const in `sink.ts` to satisfy `no-slow-types` (public API symbols require explicit types)

Closes #49

## Test plan
- [x] `deno lint` passes clean in `packages/fsm-logging-ts`
- [x] `deno check src/index.ts` passes