### PR TITLE
design: polyglot actor workers for compiled languages via local IPC

### DIFF
--- a/docs/kb/kb-001-distributed-multilang-fsm.md
+++ b/docs/kb/kb-001-distributed-multilang-fsm.md
@@ -1,8 +1,22 @@
 # KB-001: Distributed, Multi-Language FSM Execution — Architecture & Best Practices
 
-**Status:** Knowledge Base / Design Guidance **Date:** 2026-06-13 **Relates
-to:**
-[ADR-002 — Worker Execution Model](../adr/adr-002-worker-execution-model.md)
+**Status:** Knowledge Base / Design Guidance **Date:** 2026-06-13 (§3, §4
+revised 2026-07-22) **Relates to:**
+[ADR-002 — Worker Execution Model](../adr/adr-002-worker-execution-model.md),
+[SPEC-001 — Polyglot Actor Workers for Compiled Languages](../specs/spec-001-compiled-lang-actor-workers.md)
+
+> **2026-07-22 revision note:** §3 originally described a bounded
+> orchestrator-fleet-pulls-and-leases model (Stage 2 in ADR-002's terms) and a
+> not-yet-built gateway/broker for the activity tier. Both were overtaken by
+> events: ADR-002 Stage 3 (merged 2026-07-01) replaced the pull/lease dispatcher
+> with a Kubernetes-style **scheduler + node-agent (kubelet)** split for the
+> _orchestrator_ tier (`fsmscheduler` + `fsmlet`) — and the same split was
+> independently built for the _activity_ tier (`asyncOperationScheduler` +
+> `asyncOperationWorkerlet`), which this KB never described. §3 below is
+> rewritten to match the code as of 2026-07-22. The ADR-003/004 this KB used to
+> cite for the old model no longer exist as files — both were folded into
+> ADR-002 Stage 3 during the 2026-07-01 docs reorg; see that ADR for the
+> pre-Stage-3 history instead.
 
 ---
 
@@ -28,144 +42,225 @@ This KB captures the recommended architecture and the trade-offs behind it.
 The single most important idea — borrowed from **Temporal** (workflow vs
 activity) and **AWS Step Functions** (state machine vs activity worker):
 
-| Concern                       | What it does                                                                                               | Needs DB?                           | Language         |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------- | ---------------- |
-| **Orchestrator** (FSM driver) | Read instance queue → resolve state → evaluate transitions/guards → run _pure_ actions → persist macrostep | **Yes** (the only DB-touching tier) | Fixed (TS today) |
-| **Activity worker** (actor)   | Execute one unit of business logic for an `invoke`d actor: take input, do work, return output              | **No** (ideally)                    | **Any**          |
-
-The current code conflates them: the orchestrator `import()`s
-`typescript/actors/index.ts` and runs actor code **in-process**
-(`fsmworker.ts:141`). That hard-binds actors to Deno/TS and forces every actor
-to share the orchestrator's runtime and DB pool.
+| Concern                       | What it does                                                                                               | Needs DB?                                                                                                                                                     | Language         |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| **Orchestrator** (FSM driver) | Read instance queue → resolve state → evaluate transitions/guards → run _pure_ actions → persist macrostep | **Yes** (the only DB-touching tier)                                                                                                                           | Fixed (TS today) |
+| **Activity worker** (actor)   | Execute one unit of business logic for an `invoke`d actor: take input, do work, return output              | **No** (ideally) — but see §3.2: the node agent that supervises the actor always holds DB connections; only the actor execution itself is meant to be zero-DB | **Any**          |
 
 **Decoupling the two along a queue boundary is what makes the system both
 polyglot and connection-frugal.**
 
-> The repo is already 80% of the way here: actors run as **promise workers on
-> their own pgmq queues** (`bootstrap-fsm-modules.ts:131`,
-> `fsmpromiseworker.ts`). That queue is the seam — we just stop assuming the
-> consumer on the other side is TS.
-
 ---
 
-## 3. Recommended architecture
+## 3. Actual architecture (as of 2026-07-22)
+
+The system evolved past a bounded-fleet-pulls-and-leases model into a
+**Kubernetes-style scheduler + node-agent split, applied twice** — once for the
+orchestrator tier, once for the activity tier. This is not a hypothetical
+"recommended" design; it is what the code does today.
 
 ```
-              POST /fsm/instances                 (API: thin, no worker lifecycle)
-                     │
-                     ▼
-     create_fsm_instance_from_name_v2()            (PG function)
-       • INSERT fsm_instance (worker_locked=false)
-       • pgmq.send("master_worker_dispatch_queue", instance_row)
-                     │
-                     ▼
-     ┌───────────────────────────────────────────┐
-     │   Orchestrator FLEET  (N standing procs)   │  ← NOT one process per instance
-     │   • lease instance via lock_fsm_instance   │
-     │   • multiplex many instances per process   │
-     │   • small pg Pool each, behind PgBouncer   │
-     └───────────────────────────────────────────┘
-                     │  on invoke(actor)
-                     ▼
-     pgmq / broker:  activity task  { actor, version, input, instance_id, corr_id }
-                     │
-     ┌───────────────┼───────────────┬───────────────┐
-     ▼               ▼               ▼               ▼
-TS activity     Python activity   Rust activity   Go activity     ← polyglot fleet
-worker          worker            worker          worker             (NO direct DB)
-     │               │               │               │
-     └───────────────┴───────────────┴───────────────┘
-                     │  result event
-                     ▼
-     back onto the instance queue → orchestrator resumes
+         POST /fsm/instances / fsmctl        (API: thin, no worker lifecycle)
+                │
+                ▼
+enqueue_fsm_dispatch_v2()                    (PG function, control plane)
+  • INSERT fsm_dispatch_queue (status='pending')
+  • pg_notify('fsm_scheduler_work', instance_id)
+                │
+                ▼
+┌─────────────────────────────────────────────────────┐
+│ fsmscheduler  — control plane, kube-scheduler equiv. │
+│ LISTEN fsm_scheduler_work                            │
+│ → schedule_next_pending(): SELECT FOR UPDATE SKIP    │
+│     LOCKED, score by fsm_modules match + free        │
+│     capacity on fsm_daemon_node, UPDATE 'scheduled',  │
+│     pg_notify('fsm_fsmlet_work_<id>')  ← push-assign │
+└─────────────────────────────────────────────────────┘
+                │
+                ▼
+┌─────────────────────────────────────────────────────┐
+│ fsmlet fleet — node agents, kubelet equiv.           │
+│ (N standing processes, NOT one per instance)         │
+│ LISTEN fsm_fsmlet_work_<id>, fsm_worker_stop         │
+│ claimScheduledForFsmlet() → startFSMWorkerWithDBLock │
+│   (in-process, Semaphore(maxConcurrency)-bounded)    │
+│ lock_fsm_instance = defense-in-depth atomic lease    │
+│ heartbeat every 5s → fsm_daemon_node                 │
+└─────────────────────────────────────────────────────┘
+                │  on xstate.invoke(actor)
+                ▼
+create_promise_queue_and_send_event_from_fsm_instance_id_v2()
+  • INSERT async_operation_instance_and_async_operation_workerlet (status='pending')
+  • pg_notify('async_operation_scheduler_work')
+                │
+                ▼
+┌─────────────────────────────────────────────────────┐
+│ asyncOperationScheduler — control plane,             │
+│ kube-scheduler equiv. for the ACTIVITY tier          │
+│ LISTEN async_operation_scheduler_work                │
+│ → async_operation_schedule_next_pending(): SELECT    │
+│     FOR UPDATE SKIP LOCKED, score by supported-op    │
+│     match + free capacity, UPDATE, pg_notify         │
+│     ('async_op_workerlet_work_<id>')  ← push-assign  │
+└─────────────────────────────────────────────────────┘
+                │
+                ▼
+┌─────────────────────────────────────────────────────┐
+│ asyncOperationWorkerlet fleet — node agents, kubelet │
+│ equiv. for the ACTIVITY tier                         │
+│ LISTEN async_op_workerlet_work_<id>                  │
+│ claimScheduledForAsyncOperationWorkerlet()           │
+│ → startPromiseWorkerForLang(): one warm worker per   │
+│     active queue, dispatched by fsmLanguage:         │
+│       TS      → in-process, shares workerlet's Pool  │
+│       Python   → subprocess, OWN psycopg2 connection │
+│       Rust/Go  → see §3.3 (the actual open problem)  │
+│ heartbeat every 5s → async_operation_workerlet       │
+└─────────────────────────────────────────────────────┘
+                │  result archived by the TS orchestrator
+                ▼
+back onto the instance's fsm queue → fsmlet resumes the FSM instance
 ```
 
-### 3.1 Replace "one process per instance" with a bounded orchestrator fleet
+### 3.1 Orchestrator tier: `fsmscheduler` + `fsmlet` (Stage 3, ADR-002)
 
-**Problem with today's dispatcher:** `run-fsm-dispatch-daemon.ts:45` does
-`new Deno.Command(...).spawn()` per dispatch message, and each child runs
-`bootstrapFsmModules()` → `new Pool()` (`bootstrap-fsm-modules.ts:51`). So:
+`fsmlet.ts` documents itself as "node agent (kubelet equivalent)" and
+`fsmscheduler.ts` as "control-plane routing process (kube-scheduler
+equivalent)." This landed 2026-07-01 (commit `8a22689`, "replace pgmq dispatch
+with table-scan + pg_notify scheduler model") and fully superseded the old
+`run-fsm-dispatch-daemon.ts` pgmq-pull dispatcher this KB used to describe.
 
-```
-connections ≈ (active instances) × (pool size per worker)
-processes   ≈ active instances
-```
-
-1 000 live FSMs ⇒ ~1 000 processes and potentially thousands of PG connections.
-That is the connection explosion you want to avoid.
-
-**Fix:** a **fixed-size fleet** (e.g. 4–16 long-running orchestrator processes)
-that each **lease and multiplex many instances**. This is the Temporal worker
-model: a bounded fleet polling shared queues, each running thousands of
-executions cooperatively (async, not 1 thread/process per execution).
+The bounded-fleet **mechanics** this KB originally called for are in fact
+present: one `fsmlet` process is long-running, holds a `Semaphore` sized by
+`maxConcurrency` (default 8) and an `activeWorkers` map, and multiplexes that
+many FSM instances concurrently on one event loop — not one process per
+instance. That math still holds:
 
 ```
 connections ≈ (fleet size) × (small pool size)        ← independent of instance count
 processes   ≈ fleet size                               ← bounded
 ```
 
-Concurrency safety is **already in place**: `lock_fsm_instance` does an atomic
-`UPDATE … WHERE worker_locked = false` on `fsm_instance` (see ADR-003/004 +
-`fsm-instance-lock.ts`). A fleet member leases an instance, drives it until it
-blocks/sleeps/terminates, releases the lock, moves on. The pgmq visibility
-timeout makes lease loss self-healing.
+What's different from the originally-described model is **how an instance gets
+to a fsmlet**. There is no anonymous pool of workers racing to pull off a shared
+queue and lease via `lock_fsm_instance` alone. Instead a **centralized
+`fsmscheduler`** does placement: it claims the oldest pending dispatch entry
+from `fsm_dispatch_queue`, scores registered fsmlets in `fsm_daemon_node` by
+JSONB module-containment + free capacity, and **push-assigns** the work to one
+named fsmlet via that fsmlet's own `pg_notify` channel (`fsm_fsmlet_work_<id>`)
+— per ADR-002 §Stage 3: "the node agent (kubelet / fsmlet) should not decide
+what to run — it should only run what the scheduler assigns to it."
 
-> Keep the dispatch queue (ADR-004) — it gives near-zero dispatch latency (push,
-> not scan). Just change the consumer from "spawn a process" to "an idle fleet
-> slot picks it up." Keep the watchdog scan as the recovery net (ADR-004
-> §Watchdog).
+`lock_fsm_instance` (`fsm-instance-lock.ts`) is still in the code
+(`fsmworker.ts:179,188`) but now plays a narrower role: a defense-in-depth
+atomic lease taken by `startFSMWorkerWithDBLock` immediately under the
+scheduler's assignment, not the primary dispatch mechanism.
 
-**This directly satisfies requirement #3:** the API only does
-`create + enqueue`; a pre-warmed fleet reacts. Worker startup is fully
-out-of-band, and there is no per-request process spawn.
+### 3.2 Activity tier: `asyncOperationScheduler` + `asyncOperationWorkerlet` (mirrors §3.1 exactly)
 
-### 3.2 Make actors polyglot via the queue, not via `import()`
+This tier was **not described anywhere in the earlier version of this KB** — it
+was built after 2026-06-13 and mirrors §3.1 one-to-one rather than following the
+gateway/broker design the original 2026-06-13 KB recommended for this boundary
+(see §3.3 for where that transport question stands today).
 
-The orchestrator must **never** call actor code directly. On `xstate.invoke` it
-enqueues an **activity task** and returns; the actor result arrives later as an
-event on the instance queue (this is exactly what the promise-worker path
-already models).
+- `asyncOperationScheduler.ts` doc comment: "Async-operation scheduler —
+  control-plane routing process (kube-scheduler equivalent) for async-operation
+  workerlets." It LISTENs on `async_operation_scheduler_work`, calls
+  `async_operation_schedule_next_pending()` (claim + filter/score + assign +
+  notify in one PG transaction, scanning
+  `async_operation_instance_and_async_operation_workerlet` and
+  `async_operation_workerlet`), and push-assigns to one named workerlet via
+  `async_op_workerlet_work_<id>`.
+- `asyncOperationWorkerlet.ts` doc comment: "Async-operation workerlet — node
+  agent (analogous to fsmlet)." It registers in `async_operation_workerlet`,
+  LISTENs on its own channel, claims assigned work via
+  `claimScheduledForAsyncOperationWorkerlet`, and runs **one long-running worker
+  per active actor queue**, tracked in the same `Semaphore` + `activeWorkers`
+  shape as `fsmlet`.
 
-Folder convention extends cleanly:
+So the "activity worker" in §2's table is really **two things bundled
+together**, with different DB-connection stories:
 
-```
-creditCheck/v01/
-  fsm.json
-  typescript/actors/index.ts      # TS-implemented actors
-  python/actors/...               # Python-implemented actors
-  rust/actors/...                 # Rust-implemented actors
-```
+1. **The workerlet itself (control-plane facing)** — registration, heartbeat,
+   claim, its dedicated LISTEN connection. This **always** holds DB connections,
+   by design, exactly like a fsmlet does. This part of the activity tier was
+   never going to be zero-DB once it became a kubelet — the "Needs DB? No
+   (ideally)" cell in §2's table only ever applied to the next layer down.
+2. **The per-actor-language execution the workerlet supervises**
+   (`startPromiseWorkerForLang`) — this is where "zero DB connections in the
+   polyglot worker" is actually won or lost, and today it is **not** won for
+   every language. See §3.3.
 
-The compiler (`fsm-compiler-ts` / `fsm-compiler-py`) registers, per actor,
-**which language/queue implements it**. Each language has its own
-activity-worker fleet subscribed to the actor queues it owns. Adding a language
-= deploying a new fleet; the orchestrator is unchanged.
+No gateway or broker process exists anywhere in the current code — the Activity
+Gateway prototyped 2026-06-14 was reverted 2026-06-23 as "too complex for now",
+and the system's actual answer to "how do we decouple the activity tier" turned
+out to be _another_ scheduler/kubelet pair, not the gateway/broker this KB
+recommended.
 
-**Contract (language-neutral):** an activity worker receives
-`{ actor, version, input, instance_id, correlation_id }` and returns
-`{ output | error }`. No FSM internals, no SQL. Idempotency via `correlation_id`
-(at-least-once delivery).
+### 3.3 The open problem: how should `asyncOperationWorkerlet` do polyglot?
 
-### 3.3 Transport choice for the polyglot boundary (the DB-connection lever)
+Inside `startPromiseWorkerForLang` (`asyncOperationWorkerlet.ts:92–145`), the
+per-language dispatch is uneven, and this is a concrete, current gap — not a
+future hypothetical:
 
-This is where "minimize DB connections" is won or lost. Three options:
+| Language   | Mechanism                                                      | Holds its own DB connection?                                                      |
+| ---------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| TypeScript | in-process, `import()`, polls PGMQ via `startFSMPromiseWorker` | No — shares the workerlet's own pool (fine; same process)                         |
+| Python     | `Deno.Command` subprocess running `fsmpromiseworker.py`        | **Yes** — its own `psycopg2` connection, independent poll → invoke → archive loop |
+| Rust       | — (see below)                                                  | n/a — nothing runs today                                                          |
+| Go         | — (see below)                                                  | n/a — nothing runs today                                                          |
 
-| Option                                                  | Polyglot worker connects to                 | DB conns from actor fleet                    | Notes                                                                                                            |
-| ------------------------------------------------------- | ------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **A. Direct pgmq**                                      | Postgres (pg client per lang)               | **High** — every actor worker holds PG conns | Simplest, but every Python/Rust/Go worker = more PG connections. **Defeats the goal.**                           |
-| **B. Activity Gateway** (recommended)                   | A thin gRPC/HTTP service that owns the pool | **Low** — only the gateway pool              | One service brokers task fetch + result submit. Polyglot workers hold **zero** PG connections.                   |
-| **C. Neutral broker** (NATS / Redis Streams / RabbitMQ) | The broker                                  | **Low** — a bridge moves pgmq↔broker         | pgmq stays the durable source of truth; a single bridge process syncs to a broker that polyglot workers consume. |
+Python's path is exactly **Option A** below: one more DB connection per active
+queue, growing with actor traffic, independent of
+`fsm_dispatch_queue`/`fsm_daemon_node` connection counts. It works in production
+today but is an accepted stopgap, not the target state. Rust and Go have **no
+implementation at all** — `startPromiseWorkerForLang` just logs
+`"Promise worker for lang={lang} not yet implemented"` and returns.
 
-**Recommendation:** keep **pgmq as the durable backbone**, and put either an
-**Activity Gateway (B)** or a **broker bridge (C)** between Postgres and the
-polyglot actor fleet. Then:
+Transport options for this boundary are on the table (kept from the earlier
+version of this KB, since the trade-offs are unchanged even though the
+surrounding architecture is) — **none is decided in this KB**. This is the open
+problem SPEC-001 (Draft, issue #55) is working through:
 
-- The **only** tier holding PG connections is the orchestrator fleet (+
-  gateway/bridge).
-- The polyglot actor fleet scales to dozens of languages/processes **without
-  adding a single PG connection**.
+| Option                                         | Polyglot worker connects to                                                                 | DB conns from actor execution                              | Notes                                                                                        |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **A. Direct pgmq/PG**                          | Postgres (pg client per lang)                                                               | **High** — every actor process holds PG conns              | Simplest, but every extra language = more PG connections. **This is Python's current path.** |
+| **B. Activity Gateway**                        | A thin gRPC/HTTP service that owns the pool                                                 | **Low** — only the gateway pool                            | Prototyped 2026-06-14, reverted 2026-06-23 as too complex for the need at the time.          |
+| **C. Local IPC to the supervising node agent** | The `asyncOperationWorkerlet` itself, over some local transport (e.g. a Unix domain socket) | **Zero** — the actor process opens no DB connection at all | No new service; reuses the workerlet's own lifecycle machinery.                              |
 
-### 3.4 Put a connection pooler in front of Postgres — non-negotiable at scale
+Fixing Rust/Go the same way Python was fixed (Option A: a subprocess that owns
+its own PG connection) would repeat Option A's connection-growth problem once
+more per compiled language. Re-attempting the reverted Activity Gateway (Option
+B) remains a candidate, weighed against its earlier "too complex for now"
+verdict, given there is still no live actor blocked on this today. Which option
+(or a variant) is right — and the transport, container-vs-plain- subprocess, and
+warm-vs-cold-per-message questions underneath it — is what SPEC-001 is
+resolving. See that spec for the full options analysis, decision drivers, and
+acceptance criteria. As of this revision the spec is **Draft**: no option has
+been accepted, and Python's own-connection model plus the Rust/Go gap both still
+exist in the code today.
+
+### 3.4 Connection accounting, updated
+
+There is no gateway/broker tier in this system and none is planned. The actual
+connection-holding tiers today are:
+
+- `fsmscheduler` (1 dedicated LISTEN connection, control plane)
+- `asyncOperationScheduler` (1 dedicated LISTEN connection, control plane)
+- Each `fsmlet` (1 pool + 1 dedicated LISTEN connection for
+  `fsm_fsmlet_work_<id>`/`fsm_worker_stop`)
+- Each `asyncOperationWorkerlet` (1 pool + 1 dedicated LISTEN connection for
+  `async_op_workerlet_work_<id>`)
+- Each active **Python** promise-worker subprocess (1 `psycopg2` connection,
+  scales with active queues — the still-open gap from §3.3)
+
+Two schedulers + a LISTEN connection per fsmlet/workerlet node is a real, if
+small, addition to the connection budget that the original bounded-fleet model
+didn't account for — worth remembering when sizing the pooler below. Whether
+Rust/Go add zero connections once SPEC-001 lands depends on which option it
+settles on (§3.3): Option C would; Option A would not.
+
+### 3.5 Put a connection pooler in front of Postgres — non-negotiable at scale
 
 Regardless of the above, run **PgBouncer** (or **Supabase Supavisor**) in
 **transaction pooling** mode. Logical pools in every worker then multiplex onto
@@ -193,15 +288,27 @@ a tiny set of physical backend connections.
   helps).
 - **The queue is the contract.** Decouple tiers by message schema, not by shared
   code/imports. Version the message payload.
-- **Lease, don't assign.** Workers pull and lock (`lock_fsm_instance`); never
-  push-assign an instance to a named worker. This is what makes restart-safety
-  and horizontal scale free.
+- **Lease, don't assign — except this system deliberately does both.** The
+  original guidance here was "workers pull and lock; never push-assign an
+  instance to a named worker." ADR-002 Stage 3 explicitly chose the opposite for
+  both tiers: `fsmscheduler`/`asyncOperationScheduler` push-assign to a _named_
+  fsmlet/workerlet via a per-node `pg_notify` channel, precisely to get a
+  cluster-wide, capacity-aware placement view that a leaderless pull model can't
+  provide (module-match routing, "don't route to a node at capacity").
+  `lock_fsm_instance` is kept as a second, defense-in-depth lease underneath the
+  push-assignment — so the system gets both properties, at the cost of the
+  scheduler becoming a control-plane component whose availability now matters
+  (if all schedulers are down, nothing gets assigned even though
+  fsmlets/workerlets are healthy and idle).
 - **Backpressure = bounded fleet.** Concurrency is capped by fleet size ×
-  per-worker concurrency, itself capped by pool/pooler capacity (ADR-004
-  §Backpressure). Prefer bounding here over unbounded process spawning.
-- **Fault isolation per tier** (ADR-003): an actor crash must not kill the
-  orchestrator; an orchestrator crash must release leases (it does —
-  `cleanup()`/visibility timeout).
+  per-worker concurrency, itself capped by pool/pooler capacity (see ADR-002
+  §Stage 3, "Backpressure is real" — the scheduler checks `active_workers` vs
+  `max_concurrency` before assigning, rather than a worker self-limiting after
+  already dequeuing). Prefer bounding here over unbounded process spawning.
+- **Fault isolation per tier:** an actor crash must not kill the orchestrator;
+  an orchestrator crash must release leases (it does — `cleanup()`/visibility
+  timeout, plus a dead fsmlet's stale `fsm_daemon_node` heartbeat rows are
+  ignored by the scheduler after 30s).
 - **Observability:** propagate `instance_id` + `correlation_id` through every
   queue hop for end-to-end tracing across languages.
 - **Separate scaling axes:** API, orchestrator fleet, and each language's
@@ -211,78 +318,26 @@ a tiny set of physical backend connections.
 
 ---
 
-## 5. Concrete changes from the current code
-
-1. **Dispatcher** (`run-fsm-dispatch-daemon.ts`): stop spawning a child process
-   per message. Convert to a bounded in-process concurrency pool that leases
-   instances and runs them on the standing fleet. Reuse one `Pool` for the whole
-   process. **✅ DONE (2026-06-14):** dispatcher now uses a
-   `Semaphore(maxConcurrency)` + shared pool, leases via in-process
-   `startFSMWorkerWithDBLock`, wires the pg `fsm_worker_stop` LISTEN to
-   per-instance abort, dedups already-leased instances, and drains on shutdown.
-   CLI gains `-m/--max-concurrency` (default 8); pool `max = maxConcurrency + 4`
-   to cover the dedicated LISTEN connection (`daemon.ts`).
-2. **Orchestrator** (`fsmworker.ts`): on `xstate.invoke`, enqueue an activity
-   task instead of relying on in-process actor import. (Promise-worker plumbing
-   already exists — repoint it at a language-neutral consumer.) **↩️ REVERTED
-   (2026-06-23) — not started.** A first cut of the Activity Gateway was
-   prototyped on 2026-06-14 (option B) and then **discarded as too complex for
-   now**; the orchestrator still uses the in-process TS promise worker. See
-   "Reverted work" below.
-3. **Actors:** move from `import()` of `typescript/actors/index.ts` to
-   per-language activity-worker fleets keyed by a compiler-maintained registry.
-   Add `python/`, `rust/` sibling folders. **↩️ REVERTED (2026-06-23) — not
-   started.** The 2026-06-14 prototype (wire contract, TS worker SDK, Python
-   reference worker) was **discarded as too complex for now**. Actors remain
-   in-process TS via dynamic `import()`. See "Reverted work" below.
-4. **Connection strategy:** introduce PgBouncer/Supavisor; shrink per-worker
-   `Pool.max`; give the `LISTEN` consumer a dedicated session connection; ensure
-   polyglot actor workers reach the queue via gateway/broker, not a direct PG
-   pool. **◐ PARTIAL (2026-06-14):** the dispatcher pool is sized to the fleet,
-   and the `LISTEN` consumer already uses a dedicated never-released connection
-   (`pg-listener-for-worker-stop-event.ts`). _Remaining:_ the
-   polyglot-worker-via-gateway piece (reverted with items 2–3); and run
-   PgBouncer/Supavisor in transaction mode in front of Postgres (infra/deploy,
-   not code).
-5. **Keep:** ADR-004 dispatch queue, `lock_fsm_instance` atomic lease, watchdog
-   recovery scan — these are correct.
-
-### Reverted work — Activity Gateway prototype (2026-06-14 → discarded 2026-06-23)
-
-The Activity Gateway slice (KB §3.3 option B) was prototyped and then reverted
-as too complex for now. **What was removed:**
-
-- `apps/fsm-core-worker-ts/src/activity/` — `contract.ts`, `gateway.ts`,
-  `worker-sdk.ts`, `README.md`
-- `apps/fsm-core-worker-ts/src/cli/activity-gateway.ts`,
-  `apps/fsm-core-worker-ts/src/cli/activity-worker.ts`
-- `apps/fsm-core-worker-ts/clients/python/activity_worker.py`
-- `deno.json` tasks `activity-gateway` / `activity-worker`
-- `index.ts` activity exports
-- The `buildPromiseArchiveData` extraction in `fsmpromiseworker-helper.ts`
-  (reverted to its original self-contained `processFSMPromiseQueueMessage`)
-
-**Kept (NOT reverted):** the dispatcher bounded-fleet refactor (item 1) and the
-dispatcher-side connection facts in item 4.
-
-**To resume later:** re-extract `buildPromiseArchiveData` as the shared
-poll→complete mapping, then rebuild the gateway (owns the only pool) + a
-TS/Python worker SDK against it. The previous wire contract was:
-`POST /activity/poll | /activity/complete | /activity/fail` with
-`{ taskToken, actor, input, instanceId, correlationId }`. Consider doing the
-compiler-maintained actor registry first so descriptors are generated, not
-hand-declared.
-
----
-
-## 6. Prior art to mirror
+## 5. Prior art to mirror
 
 - **Temporal** — workflow (orchestrator) vs activity (polyglot worker); bounded
   worker fleets polling task queues; per-worker multiplexing of many executions.
+  Still the right mental model for the orchestrator/activity **split itself**
+  (§2), and for the "polyglot via a queue boundary, not `import()`" idea.
 - **AWS Step Functions** — state machine vs "activity workers" (any language)
   that poll for tasks and return results.
 - **Cadence / Netflix Conductor** — same orchestrator/worker split with polyglot
   SDKs.
+- **Kubernetes** (`kube-apiserver` / `kube-scheduler` / `kubelet`) — the model
+  actually chosen for _dispatch_, per ADR-002 Stage 3. This is a real divergence
+  from Temporal worth naming explicitly: Temporal's workers **pull** from a
+  shared task queue and lease work themselves (no central placement decision);
+  this system's schedulers **push-assign** to a specific, named node after a
+  capacity/module-match scoring pass. Both are valid distributed-worker
+  patterns, but they answer "how does a worker get work?" in opposite ways — see
+  §4's "Lease, don't assign" entry for the trade-off this bought.
 
-The chosen design = Temporal's model, with **Postgres + pgmq as the task-queue
-substrate** instead of a dedicated server.
+The chosen design, for both the orchestrator and the activity tier, is closer to
+**Kubernetes' scheduler/kubelet split** than to Temporal's worker-fleet model,
+with **Postgres doing double duty as etcd (state) and the task-queue substrate**
+instead of a dedicated scheduler server or message broker.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -36,6 +36,6 @@ Flow:
 
 ## Index
 
-| Spec | Title | Status |
-| ---- | ----- | ------ |
-| —    | —     | —      |
+| Spec                                                | Title                                                       | Status |
+| --------------------------------------------------- | ----------------------------------------------------------- | ------ |
+| [SPEC-001](spec-001-compiled-lang-actor-workers.md) | Polyglot Actor Workers for Compiled Languages via Local IPC | Draft  |

--- a/docs/specs/spec-001-compiled-lang-actor-workers.md
+++ b/docs/specs/spec-001-compiled-lang-actor-workers.md
@@ -1,0 +1,227 @@
+# SPEC-001: Polyglot Actor Workers for Compiled Languages via Local IPC
+
+| Field   | Value                                                                                     |
+| ------- | ----------------------------------------------------------------------------------------- |
+| Status  | Draft                                                                                     |
+| Date    | 2026-07-22                                                                                |
+| Authors | Niraj, Claude                                                                             |
+| Issue   | #55                                                                                       |
+| Affects | `apps/fsm-core-worker-ts`, `packages/fsm-compiler-ts`, `apps/fsm-core-example`, `docs/kb` |
+
+---
+
+## Problem
+
+`asyncOperationWorkerlet.ts`'s `startPromiseWorkerForLang` (line ~92) dispatches
+a claimed promise-actor invocation by `fsmLanguage`:
+
+- `"typescript"` — in-process, dynamic `import()`, polls PGMQ itself
+  (`startFSMPromiseWorker`).
+- `"python"` — spawns `fsmpromiseworker.py` as a subprocess, but that subprocess
+  _also_ opens its own `psycopg2` connection and runs its own independent poll →
+  invoke → archive loop.
+- `"go"` / `"rust"` — logs
+  `"Promise worker for lang={lang} not yet
+  implemented"` and returns. **No
+  worker runs at all.**
+
+The go/rust gap isn't a small wiring fix:
+`validateAsyncOperationFromFoldersV2`'s checkers for these languages
+(`check_fn.go`, `check_fn.rs`) only do a **static syntax check** (AST scan for
+Go, substring match for Rust) — there is no existing mechanism to dynamically
+invoke a compiled Go or Rust function the way `import()` does for TS or
+`importlib` does for Python. An actual invocation path has to be designed, not
+patched in.
+
+No specific actor is blocked on this today — this is proactive design work to
+close a known, documented gap (the `"not yet implemented"` log line has existed
+since the go/rust branches were stubbed) before it becomes a blocker.
+
+## Constraints
+
+From `docs/kb/kb-001-distributed-multilang-fsm.md` (standing architectural
+guidance for this exact problem space):
+
+- **Orchestrator vs. activity split**: only the orchestrator tier touches the
+  DB/queue; activity workers (actors) should ideally hold **zero** DB
+  connections (KB-001 §2, §3.2).
+- **Connection minimization**: DB connections must not scale with the number of
+  polyglot actor processes (KB-001 §1.4, §3.3). Today's Python path (one
+  `psycopg2` connection per active queue) is explicitly KB-001's "option A...
+  simplest, but defeats the goal" — an accepted stopgap, not the target state.
+- **Polyglot via queue, not via transport rebuild**: KB-001 §3.3 recommends an
+  Activity Gateway (option B) or neutral broker (option C) for the general case.
+  A full gateway (gRPC/HTTP service, its own deployment, wire contract, SDK) was
+  prototyped 2026-06-14 and **reverted 2026-06-23 as "too complex for now"**
+  (KB-001 §5, "Reverted work"). Reintroducing that scope is explicitly out of
+  bounds for this spec — this design must stay smaller than that reverted
+  prototype.
+- **Kubelet analogy already established**: `asyncOperationWorkerlet.ts`'s own
+  doc comment and ADR-002 (Stage 3, FSM-instance side) both use the Kubernetes
+  kubelet/scheduler framing. This spec keeps that framing rather than
+  introducing a new mental model.
+
+Additional constraints surfaced during interrogation:
+
+- **No confirmed container runtime** in the deploy target. The design must not
+  require Docker/Podman; a plain compiled-binary subprocess is the default.
+- **No live Go/Rust actor exists yet** — acceptance is proven with a reference
+  fixture, not a production migration.
+- **WASM-in-Deno ruled out explicitly**: compiling actors to WASM and running
+  them in-process (like TS's `import()`) was considered and rejected — real
+  actor business logic needs full OS access (outbound network calls, file I/O,
+  native libs), which WASM sandboxing would block. Not revisited in this spec.
+
+## Options considered
+
+### Option A — Direct-connection worker per language (extend today's Python model to Rust)
+
+A Rust subprocess owns its own DB connection, polls PGMQ directly, calls the
+actor function in-process, and archives the result — mirroring
+`fsmpromiseworker.py` exactly.
+
+- **Pros**: zero new design; precedent already exists and works in production
+  for Python.
+- **Cons**: adds one DB connection per active queue, directly violating KB-001's
+  connection-minimization goal; duplicates the full poll/archive/error handling
+  logic per language with no shared harness — every future compiled language
+  repeats all of it from scratch.
+
+### Option B — Revive the full Activity Gateway (gRPC/HTTP service)
+
+Rebuild the reverted 2026-06-14 prototype: a standalone gateway service owning
+the only DB pool, polyglot workers talking to it over gRPC/HTTP holding zero DB
+connections.
+
+- **Pros**: general solution for _any_ number of languages/processes; closest to
+  KB-001's fully-realized recommendation.
+- **Cons**: this is the scope that was already tried and explicitly reverted as
+  too complex; it adds a new network service to deploy, secure, and monitor, for
+  a need that currently has no live actor driving it. Disproportionate to the
+  problem size today.
+
+### Option C — Orchestrator-held poll + warm per-queue subprocess + Unix domain socket IPC (chosen)
+
+The TS orchestrator (`asyncOperationWorkerlet.ts`) keeps 100% of PGMQ
+poll/claim/archive logic — nothing moves out of it. For `"rust"` (and later
+`"go"`), `startPromiseWorkerForLang` launches one warm subprocess per active
+queue (`Deno.Command`, no container), tracked in `activeWorkers` and killed via
+the existing `AbortController`/signal pattern — the same lifecycle shape
+Python's subprocess already uses today. Instead of the subprocess polling PGMQ
+itself, the orchestrator sends it one request at a time over a **Unix domain
+socket** and awaits the response; the subprocess never opens a DB connection.
+
+A single generic "poll + dispatch-over-socket" harness is written once in TS and
+reused for every compiled language; each language only needs a small shim that
+accepts one connection, reads one framed request, calls the named function,
+writes one framed response, and loops.
+
+- **Pros**: zero DB connections in the polyglot worker (satisfies KB-001's
+  actual goal without the gateway's deployment surface); one harness reused
+  across languages instead of a bespoke poller per language; no container
+  runtime dependency; socket transport avoids the risk of an actor's own
+  `println!`/log output corrupting a shared-stdio protocol (a real risk with
+  stdin/stdout framing, since the actor's own dependencies may write to stdout
+  unpredictably); rollback is trivial (revert to the no-op branch, zero blast
+  radius on TS/Python).
+- **Cons**: one request in flight per process at a time (matches today's
+  single-consumer-per-queue model everywhere else, so not currently a real
+  limitation); introduces a new small protocol/contract to maintain as more
+  languages are added; adds one indirection hop for debugging (TS ↔ socket ↔
+  compiled process) versus in-process TS.
+
+### Option D — Do nothing (smaller hammer): leave go/rust unimplemented until an actor needs it
+
+- **Pros**: zero effort now; avoids speculative complexity for a need with no
+  current live driver.
+- **Cons**: the gap is already documented and known; deferring means the first
+  real Go/Rust actor request becomes blocked on this design work landing on the
+  critical path, instead of already being solved infrastructure.
+
+## Decision
+
+**Option C.** It is the smallest design that actually satisfies KB-001's
+connection-minimization and orchestrator/activity-split goals, without
+re-entering the scope that got the Activity Gateway reverted. Decision drivers,
+in order:
+
+1. **Zero DB connections on the polyglot side** — the one property Option A
+   fails and Option C achieves without Option B's cost.
+2. **Reuse over rebuild** — Option C reuses existing lifecycle machinery
+   (`activeWorkers`, `AbortController`, the lazy-compile-and-cache pattern
+   already used for `check_fn.go`/`check_fn.rs`) rather than introducing a new
+   service class.
+3. **No new infra requirement** — ruled out containers (unconfirmed runtime) and
+   ruled out a gateway service (new deployable) in favor of a subprocess +
+   socket, both of which are things this codebase already does today (Python
+   subprocess, LISTEN-based sockets from Postgres).
+4. **Protocol robustness** — Unix domain socket over stdin/stdout specifically
+   to avoid a corrupted-framing failure mode where the actor's own output
+   pollutes the RPC channel.
+
+**First reference implementation targets Rust.** Go follows later against the
+same contract (reusing `check_fn.go`'s existing AST-based validation approach
+for its own checker); the contract is written generically enough that adding Go
+should not require renegotiating the protocol.
+
+## Consequences & migration
+
+- **No migration required.** Go/Rust have zero workers today — this is net-new
+  capability. TS and Python branches of `startPromiseWorkerForLang` are
+  untouched.
+- **What gets harder**: one more artifact type to build/ship per compiled
+  language (a shim binary conforming to the socket contract); one more contract
+  to keep stable as languages are added; debugging a Rust actor invocation now
+  involves a socket hop instead of a single in-process call.
+- **Rollback story**: the new code path is fully gated on
+  `fsmLanguage ===
+  "rust"` (soon `"go"`) inside `startPromiseWorkerForLang`.
+  Reverting means restoring the no-op/log-warning branch — no impact on TS or
+  Python actors, no schema or data migration to undo.
+- **Explicitly deferred, not solved by this spec**: per-actor dependency
+  isolation (e.g. two Rust actors needing incompatible native library versions)
+  — this would need containers or per-actor build isolation, which is out of
+  scope given the "no confirmed container runtime" constraint. If that need
+  arises, containerizing the same socket-shim subprocess is a compatible future
+  upgrade, not a redesign.
+
+## Acceptance criteria
+
+- [ ] A language-neutral shim contract is documented: request/response JSON
+      shape, socket framing (e.g. length-prefixed or newline-delimited over the
+      Unix socket), startup handshake, one-request-at-a-time semantics, and
+      graceful-shutdown signal — reusing the activity contract shape already
+      defined in KB-001 §3.2
+      (`{actor, version, input, instance_id,
+      correlation_id}` →
+      `{output | error}`) rather than inventing a new shape.
+- [ ] `startPromiseWorkerForLang`'s `"rust"` branch launches a warm subprocess
+      per active queue via `Deno.Command` (no container), tracked in
+      `activeWorkers` and terminated via the existing
+      `signal.addEventListener("abort", ...)` pattern already used for Python.
+- [ ] The TS orchestrator retains sole ownership of `readMessage` (PGMQ poll)
+      and `archiveEventFromFsmPromiseTypeWorker` (archive) — the Rust subprocess
+      never opens a DB connection, verified by inspection/log audit of the
+      reference implementation.
+- [ ] A reference Rust actor + shim exists (fixture under
+      `apps/fsm-core-example/` or a test-only fixture) proving the full path
+      end-to-end: dispatch → claim → orchestrator forwards over the Unix socket
+      → Rust shim executes the actor function → response returned → archived.
+- [ ] `validateAsyncOperationFromFoldersV2`'s Rust checker (`check_fn.rs`)
+      either continues to pass unmodified, or is extended — decided and
+      documented in the implementation issue — if the shim contract requires
+      confirming more than "a function with this name exists" (e.g. a specific
+      entrypoint that speaks the socket protocol).
+- [ ] Failure modes are handled and covered by the reference implementation:
+      subprocess crash mid-request (orchestrator does not hang indefinitely —
+      timeout/abort path required), socket connect failure at startup (surfaced
+      as a warning; queue not marked active, matching today's `pgmqQueueExists`
+      guard behavior), and clean shutdown drains without leaving orphaned
+      sockets or zombie processes.
+- [ ] Go is explicitly out of scope for the first implementation, but the shim
+      contract is validated as polyglot-ready (not Rust-specific) before
+      merging, so a Go shim can follow later without a protocol renegotiation.
+
+## Implementation
+
+<!-- Filled in after acceptance: links to implementation issues and PRs. -->


### PR DESCRIPTION
## Summary
- Closes the documented gap where `startPromiseWorkerForLang` no-ops for `go`/`rust` actors (no invocation path exists today for compiled languages).
- Proposes keeping the TS orchestrator as the sole DB/queue-touching tier, with a warm per-queue subprocess (no container) speaking a small Unix-domain-socket IPC contract — a scoped-down version of KB-001's Activity Gateway recommendation, sized well below the gRPC/HTTP gateway prototype that was reverted 2026-06-23 as too complex.
- First reference implementation targets Rust; Go follows the same contract later.

Spec: docs/specs/spec-001-compiled-lang-actor-workers.md
Closes #55

## Test plan
- [ ] Human review of the spec's options/decision/acceptance-criteria in this PR
- [ ] No code changes in this PR — spec-only, per AGENTS.md design path