### PR TITLE
chore(compiler-ts): drop stale V2 suffix from async operation validation

### DIFF
--- a/apps/fsm-core-example/fsm/creditCheck/v01/fsm-core-xstate-fleet-journey-test.ts
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/fsm-core-xstate-fleet-journey-test.ts
@@ -26,7 +26,7 @@ import { replaceUnderscoresWithSpaces } from "@pgfsm/compiler";
 const fsm_name = "creditCheck";
 const fsm_version = "v01";
 
-// validateSyncOperationFromFolders / validateAsyncOperationFromFoldersV2 expect
+// validateSyncOperationFromFolders / validateAsyncOperationFromFolders expect
 // the *parent* of per-FSM folders (e.g. ".../fsm", containing "creditCheck/v01").
 const FSM_FOLDER_PATH = import.meta.dirname!.split("/").slice(0, -2).join("/");
 const SKIP_DIRS = ["carVitals", "taskMachineConfig"];

--- a/apps/fsm-core-worker-ts/src/asyncOperationWorkerlet/asyncOperationWorkerlet.ts
+++ b/apps/fsm-core-worker-ts/src/asyncOperationWorkerlet/asyncOperationWorkerlet.ts
@@ -15,7 +15,7 @@ import {
   type ActorPluginValidationResult,
   type ActorReference,
   type OperationLang,
-  validateAsyncOperationFromFoldersV2,
+  validateAsyncOperationFromFolders,
   type WorkflowType,
 } from "@pgfsm/compiler";
 import { startFSMPromiseWorker } from "./fsmpromiseworker.ts";
@@ -148,7 +148,7 @@ async function startPromiseWorkerForLang(
  * Async-operation workerlet — node agent (analogous to fsmlet).
  *
  * On startup:
- *   1. validateAsyncOperationFromFoldersV2 to discover and verify actors.
+ *   1. validateAsyncOperationFromFolders to discover and verify actors.
  *   2. Load each verified async operation into async_operation_meta via loadAsyncOperation.
  *   3. Registers itself in async_operation_workerlet with the full supported-op list.
  *   4. Opens a dedicated LISTEN connection on async_op_workerlet_work_<id>.
@@ -177,7 +177,7 @@ export async function startAsyncOperationWorkerlet(
   );
 
   // Step 1: validate async operations from folders.
-  const validationResults = await validateAsyncOperationFromFoldersV2(
+  const validationResults = await validateAsyncOperationFromFolders(
     folderPath,
     workflowType,
     skipDirs,

--- a/packages/fsm-compiler-ts/src/cli/index.ts
+++ b/packages/fsm-compiler-ts/src/cli/index.ts
@@ -11,7 +11,7 @@ import {
   isOperationLang,
   loadFsmJSONFromFolders,
   SUPPORTED_OPERATION_LANGS,
-  validateAsyncOperationFromFoldersV2,
+  validateAsyncOperationFromFolders,
   validateSyncOperationFromFolders,
 } from "../index.ts";
 import type { ActorReference, OperationLang, WorkflowType } from "../index.ts";
@@ -287,7 +287,7 @@ try {
     }
     case "validate-async-operation": {
       const availableActors = await loadAvailableActors();
-      await validateAsyncOperationFromFoldersV2(
+      await validateAsyncOperationFromFolders(
         folder!,
         workflowType!,
         skipDirs,

--- a/packages/fsm-compiler-ts/src/index.ts
+++ b/packages/fsm-compiler-ts/src/index.ts
@@ -40,5 +40,5 @@ export type {
 } from "./util.ts";
 export type { WorkflowType } from "./util.ts";
 export {
-  validateAsyncOperationFromFoldersV2,
-} from "./validate-async-operation-logic-v2.ts";
+  validateAsyncOperationFromFolders,
+} from "./validate-async-operation-logic.ts";

--- a/packages/fsm-compiler-ts/src/validate-async-operation-logic.ts
+++ b/packages/fsm-compiler-ts/src/validate-async-operation-logic.ts
@@ -18,7 +18,7 @@ import {
   type WorkflowType,
 } from "./util.ts";
 
-export async function validateAsyncOperationFromFoldersV2(
+export async function validateAsyncOperationFromFolders(
   folderPath: string,
   _workflowType: WorkflowType,
   skipDirs: string[] = [],


### PR DESCRIPTION
## Summary
- Rename `validate-async-operation-logic-v2.ts` to `validate-async-operation-logic.ts`
- Rename `validateAsyncOperationFromFoldersV2` to `validateAsyncOperationFromFolders`, updating all call sites (compiler index, compiler CLI, worker actor discovery, example FSM comment)

Closes #57

## Test plan
- [x] `grep` confirms no remaining references to the old file/function names
- [x] prek pre-commit hooks (deno fmt, branch naming) passed