### PR TITLE
chore: scope CLAUDE.md per app/package, tighten AGENTS.md worktree policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@ At the start of every session, before doing anything else, ask:
 ### (a) Explore / experiment / Q&A
 
 Continue normally. Don't touch GitHub issues. Code changes are fine here —
-experiments and throwaway work don't need an issue. If exploration turns into
-real design or implementation work, stop and re-enter the gate as (b) or (c).
+experiments and throwaway work don't need an issue, a branch, or a worktree
+(there's no issue number to name one with). If exploration turns into real
+design or implementation work, stop and re-enter the gate as (b) or (c) — that's
+the point a worktree gets created.
 
 ### (b) Design / architecture → spec-driven path
 
@@ -50,10 +52,17 @@ reviewed spec, not code.
    gh issue create --title "design: <title>" --body "<one-paragraph summary + link to spec path>" --label design --assignee @me
    ```
 
-4. Open a **spec-only PR** on branch `design/<issue-number>-short-slug`. The PR
+4. Create a worktree for this branch before making any changes — see
+   [Multi-agent coordination](#multi-agent-coordination):
+
+   ```bash
+   git worktree add .claude/worktrees/design-<issue-number> -b design/<issue-number>-short-slug
+   ```
+
+5. Open a **spec-only PR** on branch `design/<issue-number>-short-slug`. The PR
    body must contain `Spec: docs/specs/spec-NNN-short-slug.md` and
    `Closes #<issue-number>`. No implementation code rides along.
-5. Humans review the design in the PR. On merge, the spec's status becomes
+6. Humans review the design in the PR. On merge, the spec's status becomes
    **Accepted**; cut implementation issues that link back to the spec. Durable,
    hard-to-reverse decisions graduate to `docs/adr/` (see `docs/specs/README.md`
    for the lifecycle).
@@ -100,6 +109,15 @@ Issues created via `gh` bypass the issue forms, so also add the matching
 `area: *` label — the component→label mapping lives in
 `.github/advanced-issue-labeler.yml`.
 
+#### Before making any changes
+
+Create a worktree for this issue's branch — see
+[Multi-agent coordination](#multi-agent-coordination):
+
+```bash
+git worktree add .claude/worktrees/<type>-<issue-number> -b <type>/<issue-number>-short-slug
+```
+
 ## Issue linking
 
 Every code-work session posts a comment on its issue so anyone can see which
@@ -116,23 +134,48 @@ Agents without a session id post their name and start time instead.
 
 ## Multi-agent coordination
 
+These rules apply to every code-work session, not only when another agent is
+known to be active — sessions can't reliably detect each other, so treat
+coordination as always-on.
+
 - **Assignment is the lock.** Never start work on an issue assigned to someone
   else. If an issue looks stale, comment and ask — don't take it.
 - **One issue, one branch.** Branch `<type>/<issue-number>-short-slug` where
   type is `feat | bug | chore | design` (e.g. `bug/142-worker-lock-timeout`).
 - **Commits reference the issue**: `fix(worker): handle lock timeout (#142)`.
-- **Agent attribution**: end commit messages with a
-  `Co-Authored-By: <agent> <noreply@...>` trailer so `git log` shows which agent
-  wrote what.
+- **Agent attribution**: never add a `Co-Authored-By: <agent> <noreply@...>`
+  trailer to commit messages — no commit in this repo should include that line.
 - **PRs include `Closes #<number>`** so merging auto-closes the issue. Design
   PRs also include the `Spec:` line.
-- **Parallel sessions use worktrees.** Default to working directly on a branch
-  in the current directory. If another agent session is already active on this
-  repo, or the user asks for isolation, create a worktree:
+- **Always work in a worktree.** Every code-work session creates its own
+  worktree before starting work — never commit directly on a branch checked out
+  in the shared working directory:
   `git worktree add .claude/worktrees/<type>-<issue-number> -b <type>/<issue-number>-slug`
   and tell the user the path. Caveat: the API dev server (port 9999) and local
   Supabase are shared services — only one worktree can run them at a time;
   coordinate before starting either, or change `PORT` in that worktree's `.env`.
+- **One worktree per session, reused across issues.** If a session pivots to a
+  second issue, reuse the same worktree — `git checkout -b` the new issue's
+  branch inside it — rather than adding another worktree directory.
+- **Clean up after merge.** Once an issue's PR merges, remove its worktree and
+  delete the local branch:
+  `git worktree remove .claude/worktrees/<type>-<issue-number>` then
+  `git branch -d <type>/<issue-number>-short-slug`. Don't remove a worktree that
+  still has uncommitted or unpushed changes.
+- **Guard against worktree sprawl.** Before creating a new worktree, run
+  `git worktree list`. If it already has more than 7 entries under
+  `.claude/worktrees/`, scan each one's PR before adding another:
+
+  ```bash
+  gh pr view <branch> --json state,url   # per worktree's branch
+  ```
+
+  - **PR merged or closed** — remove that worktree and delete its branch (same
+    as [Clean up after merge](#multi-agent-coordination) above), then proceed.
+  - **PR still open** — don't remove it silently. Tell the user which worktrees
+    are still open and let them choose: close/merge one of those PRs so its
+    worktree can be removed, or resume that session to finish the work. Only
+    remove an open-PR worktree if the user says to.
 
 ## Enforcement
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,11 +157,14 @@ coordination as always-on.
 - **One worktree per session, reused across issues.** If a session pivots to a
   second issue, reuse the same worktree — `git checkout -b` the new issue's
   branch inside it — rather than adding another worktree directory.
-- **Clean up after merge.** Once an issue's PR merges, remove its worktree and
-  delete the local branch:
+- **Clean up after merge, but never delete the remote branch.** Once an issue's
+  PR merges, remove its worktree and delete the local branch:
   `git worktree remove .claude/worktrees/<type>-<issue-number>` then
   `git branch -d <type>/<issue-number>-short-slug`. Don't remove a worktree that
-  still has uncommitted or unpushed changes.
+  still has uncommitted or unpushed changes. Do not delete the remote branch
+  (`git push origin --delete ...`, GitHub's "Delete branch" button, or
+  `gh pr merge --delete-branch`), even though the PR is merged — that's the
+  user's call, not the agent's.
 - **Guard against worktree sprawl.** Before creating a new worktree, run
   `git worktree list`. If it already has more than 7 entries under
   `.claude/worktrees/`, scan each one's PR before adding another:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,16 @@ code in this repository.
 
 ## What This Is
 
-A Finite State Machine (FSM) framework that runs workflows inside PostgreSQL,
-exposed via a Hono/Deno REST API. FSMs are defined as JSON schemas, compiled
-into database objects, and executed through the API with multiple execution
-models (direct, worker-based, promise-based).
+distributed FSM platform where:
+
+1. A single `fsm.json` can have **actors/actions/guards implemented in different
+   languages** (TS, Python, Rust, Go…).
+2. **Many instances of the same FSM** run concurrently; each instance has its
+   own durable queue and is driven forward independently.
+3. A worker **starts when an instance is created**, **out-of-band from the API**
+   (the HTTP tier never blocks on or owns worker lifecycle).
+4. **Database connections (pg Pool objects) are minimized**, even as instance
+   count and the number of polyglot actor processes grow.
 
 ## Session Workflow
 
@@ -23,137 +29,26 @@ imported below. For design/architecture sessions, use the `/design-spec` skill.
 ## Language & Runtime Management
 
 This repo uses [proto](https://moonrepo.dev/docs/proto/overview) to pin language
-versions. Deno is pinned in the root `.prototools`, Node in
-`packages/database-src/.prototools`, and Rust in the root `rust-toolchain.toml`
-(proto delegates Rust to rustup, which reads that file). CI installs from the
-same files — never hardcode toolchain versions in workflows. Key runtimes:
-
-- **Deno 2.8.1** — primary runtime for API server and compiler
-- **Node 22.16.0** — used only for `packages/database-src` (Supabase CLI)
-- **Rust 1.95.0** — for the PostgreSQL extension in
-  `packages/database-src-extension/`
-
-## Commands
-
-### API Server (`apps/fsm-core-ts-hono-deno/`)
-
-```bash
-deno run --allow-all --env-file=.env --watch main.ts   # dev server (port 9999)
-deno test                                                # run tests
-```
-
-### FSM Compiler (`packages/fsm-compiler-ts/`)
-
-```bash
-deno run --allow-all --watch src/main.ts   # dev mode
-```
-
-### Database (`packages/database-src/`)
-
-```bash
-npm run supabase:start              # start local Supabase
-npm run supabase:db:reset           # reset and re-run all migrations
-npm run supabase:gen:types          # regenerate TypeScript types
-npm run supabase:restart:with:diff  # restart and apply schema diff
-```
-
-### PostgreSQL Extension (`packages/database-src-extension/fsm_core/`)
-
-Built with `pgrx` — see the package README for build instructions.
+versions — root `.prototools` (Deno), `packages/database-src/.prototools`
+(Node), root `rust-toolchain.toml` (Rust, via rustup). Those files are the
+source of truth; CI installs from them. Never hardcode toolchain versions here
+or in workflows.
 
 ## Architecture
 
 ```
 apps/
-  fsm-core-ts-hono-deno/   # Main REST API (Hono + Deno)
-  fsm-core-db-py/          # Raw pg client helpers (Python)
-  fsm-core-db-drizzle/     # [IGNORE] Drizzle ORM experiment for fsm-core-db-ts — not used for active work
-  fsm-core-example/        # Example FSM definitions (credit check, car vitals, etc.)
+  fsm-core-ts-hono-deno/   # Main REST API (Hono + Deno) — see CLAUDE.md
+  fsm-core-worker-ts/      # Worker fleet: fsmlet/fsmscheduler dispatch-queue CLIs — see CLAUDE.md
+  fsm-core-example/        # Example FSM definitions, polyglot actors (TS/Python/Rust/Go) — see CLAUDE.md
 packages/
-  database-src/            # PostgreSQL migrations + Supabase config
+  database-src/            # PostgreSQL migrations + Supabase config — see CLAUDE.md
   database-src-extension/  # Rust PostgreSQL extension (pgrx) using ltree + pgmq
-  fsm-compiler-ts/         # JSON → database object compiler (TypeScript)
-  fsm-core-db-ts/          # Raw pg client helpers (TypeScript)
-  fsm-compiler-py/         # JSON → database object compiler (Python)
+  fsm-compiler-ts/         # JSON → database object compiler (TypeScript) — see CLAUDE.md
+  fsm-core-db-ts/          # Raw pg client helpers (TypeScript) — see CLAUDE.md
+  fsm-logging-ts/          # Shared LogTape logging config, @pgfsm/logging — see CLAUDE.md
 ```
 
-### API Server Structure (`apps/fsm-core-ts-hono-deno/`)
-
-- `app.ts` — Hono router composition, DB pool wiring
-- `deno.ts` / `node.ts` — entry points for Deno and Node runtimes
-- `env.ts` — Zod-validated environment config (`DB_TYPE`, `PORT`, `LOG_LEVEL`,
-  etc.)
-- `lib/create-app.ts` — app factory with middleware (Pino logging, request IDs,
-  CORS)
-- `lib/configure-open-api.ts` — OpenAPI/Scalar docs setup (available at `/docs`)
-- `routes/fsm/` — core FSM operations: list, create, send
-- `routes/fsmworker/` — background worker/queue processing
-- `routes/fsmpromise/` — promise/callback-based workflows
-- `stoker-src/` — OpenAPI helper utilities
-
-### Database Layer
-
-> Note: `fsm-core-db-drizzle` is a Drizzle ORM experiment for `fsm-core-db-ts` —
-> ignore it for all work.
-
-- `fsm-instance.ts` — create instances, manage state, archive events
-- `fsm-helper.ts` — load states/transitions from JSON, DB queries
-- `fsm-instance-lock.ts` — advisory lock concurrency control
-- `queue.ts` — pgmq-based event queue management
-
-### FSM Definition Format
-
-FSMs are versioned JSON files in `apps/fsm-core-example/fsm/`. Each FSM folder
-(e.g., `v01/`, `v02/`) contains:
-
-- `fsm.json` — state machine definition
-- `xstate-fsm.json` — XState 5-compatible format
-- TypeScript subdirectories for actors, actions, guards, delays
-
-### Key Dependencies
-
-- **Hono** with `@hono/zod-openapi` — REST framework + type-safe routes
-- **Drizzle ORM 0.45.1** — database access (only in `fsm-core-db-drizzle`, which
-  is ignored)
-- **XState 5** — FSM definition format
-- **Zod** — runtime validation
-- **pgmq** — PostgreSQL message queue (for worker execution model)
-- **ltree** — PostgreSQL tree structure (for state hierarchy)
-- **Pino** — structured logging
-
-### Environment Variables (`DB_TYPE` is key)
-
-- `"postgres"` — direct PostgreSQL connection
-- `"supabase"` — Supabase JS client
-- `"supabase_and_postgres"` — both clients available
-
-## Naming Conventions
-
-PostgreSQL is the source of truth. TypeScript wrappers in
-`packages/fsm-core-db-ts/src/` must stay aligned with PG function names and
-parameter names.
-
-### PG → TS Function Name Rules
-
-- Strip `_v1` / `_v2` version suffix from TS names — version is driven by
-  `FSM_SCHEMA_FN_VERSION = "v2"` in `const.ts`
-- Use camelCase matching the PG snake_case name (e.g.,
-  `archive_event_from_fsm_type_worker_v2` → `archiveEventFromFsmTypeWorker`)
-- No added verbs or abbreviations not in the PG name
-
-### Parameter Name Rules (PG schema)
-
-- All PG function parameters use `input_*` prefix (e.g., `input_fsm_name`,
-  `input_state_value`)
-- Exception: internal orchestration params keep their names (e.g.,
-  `fsm_name_param`, `event_name`, `transition_record`)
-- v1 functions still use `p_*` prefix — not to be changed (superseded by v2)
-
-### Reference Document
-
-See `packages/database-src/docs/reference/pg-ts-function-mapping.md` for the
-complete PG→TS function mapping table, including:
-
-- All 18 direct 1:1 mappings (Table 1)
-- TS functions not directly mapped to a PG function (Table 2)
-- Gap: PG functions with no TS wrapper (Table 3)
+Each linked subdirectory has its own `CLAUDE.md` with commands, file structure,
+dependencies, and naming conventions scoped to that area — consult it when
+working there instead of duplicating detail here.

--- a/apps/fsm-core-example/CLAUDE.md
+++ b/apps/fsm-core-example/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md — FSM Examples (`apps/fsm-core-example/`)
+
+Scoped guidance for example FSM definitions. Repo-wide conventions and session
+protocol live in the root `CLAUDE.md` / `AGENTS.md`.
+
+## FSM Definition Format
+
+FSMs are versioned JSON files in `apps/fsm-core-example/fsm/` (e.g.
+`creditCheck/`, `carVitals/`, `taskMachineConfig/`). Each version folder
+(`v01/`, `v02/`) contains:
+
+- `fsm.json` — state machine definition
+- `xstate-fsm.json` — XState 5-compatible format
+- `machine.ts` / `machine-with-provider.ts` — XState machine definitions
+- Per-language actor implementations, one subdirectory per language:
+  `typescript/{actions,actors,delays,guards}/`, `python/actors/`,
+  `rust/actors/`, `go/actors/` — the concrete example of the polyglot actor
+  model described in the root `CLAUDE.md`
+
+`sharedFSM/` holds definitions reused across examples (e.g. `vitalsWorkflow/`).
+Definitions target **XState 5** semantics and are consumed by
+`packages/fsm-compiler-ts/`.

--- a/apps/fsm-core-ts-hono-deno/CLAUDE.md
+++ b/apps/fsm-core-ts-hono-deno/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md — API Server (`apps/fsm-core-ts-hono-deno/`)
+
+Scoped guidance for the Hono + Deno REST API. Repo-wide conventions and session
+protocol live in the root `CLAUDE.md` / `AGENTS.md`.
+
+## Commands
+
+```bash
+deno run --allow-all --env-file=./../../.env --watch deno.ts   # dev server (port from env, default 9999)
+deno test                                                        # run tests
+```
+
+> `deno.json`'s `start`/`cli` tasks point at `main.ts` / `src/cli/index.ts` —
+> `main.ts` doesn't exist in this tree, so `deno task start` fails. Run
+> `deno.ts` directly (shown above) until that task is fixed.
+
+## Structure
+
+- `app.ts` — Hono router composition, DB pool wiring
+- `deno.ts` — Deno entry point; configures LogTape before `app.ts` loads (must
+  happen first — `app.ts` emits logs at module load time)
+- `node.ts` — Node entry point (HTTP/2, separate from the Deno path)
+- `seconddeno.ts` — second server instance on `PORT + 1`, used to test
+  advisory-lock / `lock_workflow_instance` behavior under concurrent access
+- `env.ts` — Zod-validated environment config (`DB_TYPE`, `PORT`, `LOG_LEVEL*`,
+  `OTEL_*`, etc.)
+- `logger.ts` — composition-root LogTape configuration for this process
+  (`configureApiLogger()`), via `@pgfsm/logging`
+- `lib/create-app.ts` — app factory with middleware (logging, request IDs, CORS,
+  OTel tracing)
+- `lib/configure-open-api.ts` — OpenAPI/Scalar docs setup (available at `/docs`)
+- `lib/constants.ts`, `lib/types.ts` — shared app-level constants/types
+- `middlewares/logtape-logger.ts` — HTTP access logging via `@logtape/hono`
+- `middlewares/otel-trace.ts` — OpenTelemetry span per request (enabled via
+  `OTEL_DENO`)
+- `middlewares/pino-logger.ts` — legacy Pino logger; commented out in
+  `create-app.ts`, superseded by `logtape-logger.ts`
+- `middlewares/supabase.ts` — Supabase client middleware
+- `routes/fsm/` — core FSM operations: list, create, send
+- `routes/fsmpromise/` — promise/callback-based workflows
+- `src/cli/index.ts` — CLI entry for the API's own control commands
+- `stoker-src/` — OpenAPI helper utilities
+
+## Key Dependencies
+
+- **Hono** with `@hono/zod-openapi` — REST framework + type-safe routes
+- **Zod** — runtime validation
+- **LogTape** (`@logtape/logtape`, `@logtape/hono`, `@logtape/otel`) via
+  `@pgfsm/logging` — structured logging (see
+  `packages/fsm-logging-ts/CLAUDE.md`)
+- **OpenTelemetry** (`@opentelemetry/api`) — request tracing, opt-in via
+  `OTEL_DENO`
+
+## Environment Variables (`DB_TYPE` is key)
+
+- `"postgres"` — direct PostgreSQL connection
+- `"supabase"` — Supabase JS client
+- `"supabase_and_postgres"` — both clients available
+
+See `env.ts` for the full Zod schema (`PORT`, `LOG_LEVEL` + per-category
+overrides, `OTEL_*`, `CORS_ORIGIN`, etc.).

--- a/apps/fsm-core-worker-ts/CLAUDE.md
+++ b/apps/fsm-core-worker-ts/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md — Worker Fleet (`apps/fsm-core-worker-ts/`)
+
+Scoped guidance for `@pgfsm/worker`. Repo-wide conventions and session protocol
+live in the root `CLAUDE.md` / `AGENTS.md`.
+
+## What it is
+
+The out-of-band worker fleet that drives FSM instances forward (see root
+`CLAUDE.md` point 3 — the API never owns worker lifecycle). Kubernetes-style
+split: `fsmlet` (kubelet — long-running node agent) is routed work by
+`fsmscheduler` (kube-scheduler — control plane, run once per cluster), driven
+one-shot by `fsmctl`. The `async-operation-*` CLIs are the equivalent trio for
+promise/callback-based async operations.
+
+Full CLI reference (flags, defaults, examples) lives in
+`docs/guides/CLI-USAGE.md` — read it before invoking any of these directly.
+
+## Commands
+
+```bash
+deno task fsmlet                    # node agent — claims & drives FSM workers
+deno task fsmscheduler              # control-plane router (run once per cluster)
+deno task cli                       # fsmctl — one-shot create/resume/send/stop
+deno task async-operation-workerlet # node agent for promise-based async ops
+deno task async-operation-scheduler # control-plane router for async ops
+deno task async-operation-ctl       # one-shot control CLI for async ops
+deno task check                     # deno check src/index.ts
+```
+
+## Structure (`src/`)
+
+- `cli/` — six CLI entry points (`fsmlet.ts`, `fsmscheduler.ts`, `fsmctl.ts`,
+  `async-operation-workerlet.ts`, `async-operation-scheduler.ts`,
+  `async-operation-ctl.ts`)
+- `fsmlet/` — node-agent implementation for FSM workers
+- `fsmscheduler/` — control-plane routing implementation
+- `asyncOperationWorkerlet/` — node-agent implementation for promise-based async
+  ops (includes `fsmpromiseworker.py` — a polyglot example actor, not leftover
+  Python tooling)
+- `asyncOperationScheduler/` — control-plane routing for async ops
+- `deprecated-inprocess-approach/` — legacy pre-scheduler CLI, superseded by the
+  fsmlet/fsmscheduler dispatch model; not the path for new work
+- `logger.ts` — composition-root LogTape config for this process

--- a/packages/database-src/CLAUDE.md
+++ b/packages/database-src/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md — Database (`packages/database-src/`)
+
+Scoped guidance for PostgreSQL migrations + Supabase config. Repo-wide
+conventions and session protocol live in the root `CLAUDE.md` / `AGENTS.md`.
+
+## Commands
+
+```bash
+npm run supabase:start              # start local Supabase
+npm run supabase:db:reset           # reset and re-run all migrations
+npm run supabase:gen:types          # regenerate TypeScript types
+
+# restart, diff schema, and regenerate types — pick the version bump:
+npm run supabase:restart:with:diff:withUpgradeScript:patch
+npm run supabase:restart:with:diff:withUpgradeScript:minor
+npm run supabase:restart:with:diff:withUpgradeScript:major
+```
+
+> There's no bare `supabase:restart:with:diff` script — always specify `patch` /
+> `minor` / `major` (see `package.json` for the full script list, including
+> `pgxnBuildAndPublish` for the pgxn extension release flow).
+
+PostgreSQL is the source of truth for the schema — see
+`packages/fsm-core-db-ts/CLAUDE.md` for the naming rules TypeScript wrappers
+must follow, and `docs/reference/pg-ts-function-mapping.md` for the full PG→TS
+mapping table.

--- a/packages/fsm-compiler-ts/CLAUDE.md
+++ b/packages/fsm-compiler-ts/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md — FSM Compiler (`packages/fsm-compiler-ts/`)
+
+Scoped guidance for the JSON → database object compiler. Repo-wide conventions
+and session protocol live in the root `CLAUDE.md` / `AGENTS.md`.
+
+## Commands
+
+```bash
+deno task dev             # watch mode — src/cli/index.ts
+deno task cli             # one-shot run — src/cli/index.ts
+deno task test            # deno test --allow-all test/
+deno task generate:fsm-types  # scripts/generate-fsm-json-types.ts
+deno task build:npm       # scripts/build-npm.ts (dnt npm build)
+```
+
+## What it does
+
+Compiles `fsm.json` definitions into the PostgreSQL objects that drive
+instances. See `apps/fsm-core-example/CLAUDE.md` for the source FSM definition
+format this compiler consumes.

--- a/packages/fsm-core-db-ts/CLAUDE.md
+++ b/packages/fsm-core-db-ts/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md — DB Helpers (`packages/fsm-core-db-ts/`)
+
+Scoped guidance for the raw pg client helpers. Repo-wide conventions and session
+protocol live in the root `CLAUDE.md` / `AGENTS.md`.
+
+## Structure (`src/`)
+
+- `fsm-instance.ts` — create instances, manage state, archive events
+- `fsm-helper.ts` — load states/transitions from JSON, DB queries
+- `fsm-instance-lock.ts` — advisory lock concurrency control
+- `queue.ts` — pgmq-based event queue management
+- `fsm-workerlet.ts` — `fsm_workerlet` table ops for the fsmlet node-agent
+  (dispatch-queue worker model)
+- `fsm-scheduler.ts` — FSM dispatch enqueue/resume ops for `fsmscheduler`
+- `async-operation.ts` — async-operation dispatch-table ops (promise/callback
+  workflows)
+- `async-operation-workerlet.ts` — `async_operation_workerlet` table ops for the
+  async-operation node-agent
+- `pg-utils.ts` — small pg param helpers (e.g. `toJsonbParam`)
+- `const.ts` — schema/table name constants (`FSM_SCHEMA`,
+  `FSM_SCHEMA_FN_VERSION`, `QUEUE_SCHEMA`, …)
+- `custom-type.ts` — shared types (e.g. `DBDeps`)
+- `index.ts` — public barrel export; this package is a library and only calls
+  `getLogger()` — logging is configured once by the host process (see
+  `packages/fsm-logging-ts/CLAUDE.md`)
+
+## Naming Conventions
+
+PostgreSQL is the source of truth. TypeScript wrappers here must stay aligned
+with PG function names and parameter names.
+
+### PG → TS Function Name Rules
+
+- Strip `_v1` / `_v2` version suffix from TS names — version is driven by
+  `FSM_SCHEMA_FN_VERSION = "v2"` in `const.ts`
+- Use camelCase matching the PG snake_case name (e.g.,
+  `archive_event_from_fsm_type_worker_v2` → `archiveEventFromFsmTypeWorker`)
+- No added verbs or abbreviations not in the PG name
+
+### Parameter Name Rules (PG schema)
+
+- All PG function parameters use `input_*` prefix (e.g., `input_fsm_name`,
+  `input_state_value`)
+- Exception: internal orchestration params keep their names (e.g.,
+  `fsm_name_param`, `event_name`, `transition_record`)
+- v1 functions still use `p_*` prefix — not to be changed (superseded by v2)
+
+### Reference Document
+
+See `packages/database-src/docs/reference/pg-ts-function-mapping.md` for the
+complete PG→TS function mapping table, including:
+
+- All 18 direct 1:1 mappings (Table 1)
+- TS functions not directly mapped to a PG function (Table 2)
+- Gap: PG functions with no TS wrapper (Table 3)

--- a/packages/fsm-logging-ts/CLAUDE.md
+++ b/packages/fsm-logging-ts/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md — Logging (`packages/fsm-logging-ts/`)
+
+Scoped guidance for `@pgfsm/logging`. Repo-wide conventions and session protocol
+live in the root `CLAUDE.md` / `AGENTS.md`. Full docs (rendering helpers, sink
+internals, decision tables) are in this package's `README.md` — read it before
+changing logging behavior.
+
+## What it is
+
+The single owner of logging config for the repo — wraps LogTape with one
+process-wide configurator, a shared `CATEGORY` vocabulary (`api`, `worker`,
+`db`, `compiler`, `fsmlet`), and a console sink that auto-renders
+tables/objects.
+
+## The golden rule
+
+`configureLogging()` runs exactly once per process, at the entry point — calling
+LogTape's `configure()` twice throws.
+
+- **Apps/CLIs configure**: each composition root (API `deno.ts`/`logger.ts`,
+  each worker CLI, the compiler CLI) resolves levels from its own validated env
+  and calls `configureLogging()` once. See
+  `apps/fsm-core-ts-hono-deno/CLAUDE.md` and `apps/fsm-core-worker-ts/CLAUDE.md`
+  for the entry points that do this.
+- **Libraries never configure**: they only `getLogger([CATEGORY.x, ...])` — e.g.
+  `packages/fsm-core-db-ts/` only imports `CATEGORY`, never `configureLogging`.
+- **Env is read at the composition root**, not here — this package takes
+  explicit levels (dependency injection), never reads env itself.


### PR DESCRIPTION
## Summary
- Split the single 166-line root `CLAUDE.md` into a slim orientation file plus scoped `CLAUDE.md` files per app/package, so Claude Code only loads per-area detail when actually working there.
- Fixed drift found in the process: hardcoded toolchain versions duplicating `.prototools`/`rust-toolchain.toml`, references to removed packages (`fsm-core-db-py`, `fsm-compiler-py`, `fsm-core-db-drizzle`), a broken dev command pointing at a nonexistent `main.ts`, and missing docs for `fsm-core-worker-ts` and `fsm-logging-ts`.
- Made `AGENTS.md`'s worktree-per-session rule unconditional, added explicit worktree-creation steps to both the design and issue-driven paths, plus lifecycle/cleanup and sprawl-guard guidance.
- Removed the `Co-Authored-By` agent-attribution trailer requirement.

Closes #67

## Test plan
- [x] `deno fmt` passes on all changed markdown (prek hook)
- [ ] Human review of the new CLAUDE.md file boundaries and AGENTS.md policy wording