### PR TITLE
chore: add optional local worktree-cleanup automation

### DIFF
--- a/.claude/scripts/fsm-worktree-cleanup.sh
+++ b/.claude/scripts/fsm-worktree-cleanup.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Removes worktrees (and their local branches) whose PR has merged.
+# Never touches remote branches — see AGENTS.md "Clean up after merge" policy.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+LOG="$REPO/.claude/worktree-cleanup.log"
+
+# launchd/cron don't source shell profiles, so common git/gh install
+# locations may be missing from PATH regardless of machine or user.
+for p in /opt/homebrew/bin /usr/local/bin /usr/bin /bin; do
+  case ":$PATH:" in
+    *":$p:"*) ;;
+    *) PATH="$PATH:$p" ;;
+  esac
+done
+export PATH
+
+cd "$REPO"
+{
+  echo "=== Worktree cleanup run: $(date -u +"%Y-%m-%dT%H:%M:%SZ") ==="
+
+  git fetch origin --quiet
+
+  git worktree list --porcelain | awk '
+    /^worktree / { wt=$2 }
+    /^branch /   { branch=$2; sub("refs/heads/", "", branch); print wt "\t" branch }
+  ' | while IFS=$'\t' read -r worktree_path branch; do
+    [ "$worktree_path" = "$REPO" ] && continue
+
+    if [ -n "$(git -C "$worktree_path" status --porcelain)" ]; then
+      echo "SKIP $branch: uncommitted changes in $worktree_path"
+      continue
+    fi
+
+    ahead=$(git -C "$worktree_path" rev-list --count "origin/$branch..$branch" 2>/dev/null || echo 0)
+    if [ "$ahead" != "0" ]; then
+      echo "SKIP $branch: local commits not pushed"
+      continue
+    fi
+
+    pr_state=$(gh pr list --head "$branch" --state all --json state --jq '.[0].state // "NONE"' 2>/dev/null || echo "ERROR")
+
+    case "$pr_state" in
+      MERGED)
+        git worktree remove "$worktree_path"
+        git branch -d "$branch"
+        echo "REMOVED $branch (worktree + local branch): PR merged"
+        ;;
+      CLOSED)
+        echo "REVIEW $branch: PR closed without merge — not auto-removed, check manually"
+        ;;
+      OPEN)
+        echo "SKIP $branch: PR still open"
+        ;;
+      NONE)
+        echo "SKIP $branch: no PR found for branch"
+        ;;
+      *)
+        echo "SKIP $branch: could not determine PR state ($pr_state)"
+        ;;
+    esac
+  done
+
+  echo "=== Done ==="
+} >> "$LOG" 2>&1

--- a/.claude/scripts/install-fsm-worktree-cleanup.sh
+++ b/.claude/scripts/install-fsm-worktree-cleanup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Installs a recurring job that runs fsm-worktree-cleanup.sh every ~2
+# days: launchd on macOS, cron on Linux. Generates config from this
+# machine's own paths, so it works for any user regardless of where they
+# cloned the repo. Safe to re-run — it replaces its own prior entry.
+#
+# Windows: there's no bash/git/gh runtime to hook a native scheduler into
+# directly. Run this script inside WSL (with git+gh installed and
+# authenticated there) so it takes the Linux/cron path, then point Windows
+# Task Scheduler at wsl.exe as a belt-and-suspenders trigger in case the WSL
+# instance isn't already running:
+#   schtasks /create /tn "FSM Worktree Cleanup" ^
+#     /tr "wsl.exe -e /path/to/fsm-worktree-cleanup.sh" ^
+#     /sc daily /mo 2 /st 09:00
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+CLEANUP_SCRIPT="$SCRIPT_DIR/fsm-worktree-cleanup.sh"
+LOG="$REPO/.claude/worktree-cleanup.log"
+LABEL="com.fsm.worktree-cleanup"
+MARKER="# fsm-worktree-cleanup (managed by install-fsm-worktree-cleanup.sh)"
+
+case "$(uname)" in
+  Darwin)
+    PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+    mkdir -p "$HOME/Library/LaunchAgents"
+
+    cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>$CLEANUP_SCRIPT</string>
+  </array>
+
+  <key>StartInterval</key>
+  <integer>172800</integer>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>$LOG</string>
+  <key>StandardErrorPath</key>
+  <string>$LOG</string>
+</dict>
+</plist>
+EOF
+
+    launchctl bootout "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || true
+    launchctl bootstrap "gui/$(id -u)" "$PLIST"
+
+    echo "Installed and loaded $LABEL (launchd, runs every 2 days)"
+    echo "  plist:  $PLIST"
+    echo "  script: $CLEANUP_SCRIPT"
+    echo "  log:    $LOG"
+    echo
+    echo "Run now:  launchctl kickstart -k gui/\$(id -u)/$LABEL"
+    echo "Disable:  launchctl bootout gui/\$(id -u)/$LABEL"
+    ;;
+
+  Linux)
+    CRON_LINE="0 9 */2 * * $CLEANUP_SCRIPT >> $LOG 2>&1 $MARKER"
+    ( crontab -l 2>/dev/null | grep -vF "$MARKER"; echo "$CRON_LINE" ) | crontab -
+
+    echo "Installed cron entry (runs at 09:00 on every odd day-of-month, ~every 2 days):"
+    echo "  $CRON_LINE"
+    echo "  log: $LOG"
+    echo
+    echo "View:    crontab -l"
+    echo "Remove:  crontab -l | grep -vF '$MARKER' | crontab -"
+    ;;
+
+  *)
+    echo "Unsupported OS: $(uname)." >&2
+    echo "On Windows, run this installer inside WSL — see the comment at the top of this file." >&2
+    exit 1
+    ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ Thumbs.db
 .claude/.current-session-id
 CLAUDE.local.md
 .claude/worktrees/
+.claude/worktree-cleanup.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,29 @@ managers with desktop apps. Fix it by committing from a **terminal**, or launch
 your editor from an activated shell (e.g. `code .`). Windows users installing
 via proto/rustup get the shims on the user `PATH` automatically.
 
+### Optional: automatic worktree cleanup
+
+`AGENTS.md` has agents (and you, if you pair with one) create a git worktree per
+issue under `.claude/worktrees/`. These accumulate over time as PRs merge, and
+cleaning them up by hand is easy to forget. If you'd rather it happen
+automatically:
+
+```bash
+.claude/scripts/install-fsm-worktree-cleanup.sh
+```
+
+This registers a job that runs every ~2 days (`launchd` on macOS, `crontab` on
+Linux) and, for each worktree, checks its branch's PR: if merged, it removes the
+worktree and deletes the local branch — **it never deletes the remote branch**,
+matching the cleanup policy in `AGENTS.md`. Worktrees with uncommitted or
+unpushed changes are left alone. Logs go to `.claude/worktree-cleanup.log`
+(git-ignored).
+
+On Windows, run the installer inside WSL (with `git`/`gh` installed and
+authenticated there) — see the comment at the top of the script for the Task
+Scheduler + WSL setup. This step is entirely optional; skip it if you'd rather
+clean up worktrees manually.
+
 ### Running the project
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds `.claude/scripts/fsm-worktree-cleanup.sh`: checks each git worktree's branch PR state and, if merged, removes the worktree + deletes the local branch — never the remote branch, per `AGENTS.md`'s cleanup policy. Portable (derives repo root from its own location).
- Adds `.claude/scripts/install-fsm-worktree-cleanup.sh`: one-shot installer that registers a recurring job (`launchd` on macOS, `crontab` on Linux) to run the cleanup script every ~2 days; documents the WSL + Task Scheduler path for Windows.
- Ignores `.claude/worktree-cleanup.log` (the script's run log).
- Documents this as an **optional** opt-in step in `CONTRIBUTING.md`.

Closes #71

## Test plan
- [x] Ran the installer manually on macOS — `launchd` job loads and the script runs cleanly, logging to `.claude/worktree-cleanup.log`.
- [x] `deno fmt` passes via the prek pre-commit hook.
- [ ] Manual verification on Linux (crontab path) and Windows/WSL — not tested in this environment.