### PR TITLE
fix(compiler-ts): allow non_snake_case on generated Rust names

### DIFF
--- a/apps/fsm-core-example/fsm/carVitals/v01/rust/delays/mod.rs
+++ b/apps/fsm-core-example/fsm/carVitals/v01/rust/delays/mod.rs
@@ -1,4 +1,5 @@
 // Delay: 1000
+#[allow(non_snake_case)]
 pub fn delay1000(context: &serde_json::Value, event: &serde_json::Value) -> u64 {
     // TODO: implement delay logic (return ms)
     0

--- a/apps/fsm-core-example/fsm/creditCheck/v01/rust/actions/mod.rs
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/rust/actions/mod.rs
@@ -1,94 +1,113 @@
 // Action: assignSSN
+#[allow(non_snake_case)]
 pub fn assignSSN(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignFirstName
+#[allow(non_snake_case)]
 pub fn assignFirstName(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignLastName
+#[allow(non_snake_case)]
 pub fn assignLastName(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignErrorMessage
+#[allow(non_snake_case)]
 pub fn assignErrorMessage(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignCreditScoreError
+#[allow(non_snake_case)]
 pub fn assignCreditScoreError(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignEquiGavinScore
+#[allow(non_snake_case)]
 pub fn assignEquiGavinScore(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: saveReportEquiGavin
+#[allow(non_snake_case)]
 pub fn saveReportEquiGavin(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignEquiGavinScoreFetch
+#[allow(non_snake_case)]
 pub fn assignEquiGavinScoreFetch(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignGavUnionScore
+#[allow(non_snake_case)]
 pub fn assignGavUnionScore(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: saveReportGavUnion
+#[allow(non_snake_case)]
 pub fn saveReportGavUnion(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignGavUnionScoreFetch
+#[allow(non_snake_case)]
 pub fn assignGavUnionScoreFetch(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignGavperianScore
+#[allow(non_snake_case)]
 pub fn assignGavperianScore(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: saveReportGavperian
+#[allow(non_snake_case)]
 pub fn saveReportGavperian(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignGavperianScoreFetch
+#[allow(non_snake_case)]
 pub fn assignGavperianScoreFetch(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignMiddleScore
+#[allow(non_snake_case)]
 pub fn assignMiddleScore(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: saveCreditProfile
+#[allow(non_snake_case)]
 pub fn saveCreditProfile(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignInterestRateOptions
+#[allow(non_snake_case)]
 pub fn assignInterestRateOptions(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: emailUser
+#[allow(non_snake_case)]
 pub fn emailUser(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: emailSalesTeam
+#[allow(non_snake_case)]
 pub fn emailSalesTeam(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }

--- a/apps/fsm-core-example/fsm/creditCheck/v01/rust/actors/checkBureau/checkBureau.rs
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/rust/actors/checkBureau/checkBureau.rs
@@ -1,4 +1,5 @@
 // Actor: checkBureau
+#[allow(non_snake_case)]
 pub fn checkBureau(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement actor logic
 }

--- a/apps/fsm-core-example/fsm/creditCheck/v01/rust/actors/mod.rs
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/rust/actors/mod.rs
@@ -1,3 +1,4 @@
 #[path = "checkBureau/checkBureau.rs"]
+#[allow(non_snake_case)]
 mod checkBureau;
 pub use checkBureau::checkBureau;

--- a/apps/fsm-core-example/fsm/creditCheck/v01/rust/guards/mod.rs
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/rust/guards/mod.rs
@@ -1,22 +1,26 @@
 // Guard: allSucceeded
+#[allow(non_snake_case)]
 pub fn allSucceeded(context: &serde_json::Value, event: &serde_json::Value) -> bool {
     // TODO: implement
     true
 }
 
 // Guard: equiGavinReportFound
+#[allow(non_snake_case)]
 pub fn equiGavinReportFound(context: &serde_json::Value, event: &serde_json::Value) -> bool {
     // TODO: implement
     true
 }
 
 // Guard: gavUnionReportFound
+#[allow(non_snake_case)]
 pub fn gavUnionReportFound(context: &serde_json::Value, event: &serde_json::Value) -> bool {
     // TODO: implement
     true
 }
 
 // Guard: gavperianReportFound
+#[allow(non_snake_case)]
 pub fn gavperianReportFound(context: &serde_json::Value, event: &serde_json::Value) -> bool {
     // TODO: implement
     true

--- a/apps/fsm-core-example/fsm/creditCheck/v02/rust/actions/mod.rs
+++ b/apps/fsm-core-example/fsm/creditCheck/v02/rust/actions/mod.rs
@@ -1,104 +1,125 @@
 // Action: rootInterpreterIdSuccess
+#[allow(non_snake_case)]
 pub fn rootInterpreterIdSuccess(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: rootInterpreterIdError
+#[allow(non_snake_case)]
 pub fn rootInterpreterIdError(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: verifyCredentialsSuccess
+#[allow(non_snake_case)]
 pub fn verifyCredentialsSuccess(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: CheckingEquiGavinEntry
+#[allow(non_snake_case)]
 pub fn CheckingEquiGavinEntry(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: CheckingEquiGavinExit
+#[allow(non_snake_case)]
 pub fn CheckingEquiGavinExit(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: CheckingForExistingReportExit
+#[allow(non_snake_case)]
 pub fn CheckingForExistingReportExit(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: equiGavinDBActorSuccess
+#[allow(non_snake_case)]
 pub fn equiGavinDBActorSuccess(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: saveReport
+#[allow(non_snake_case)]
 pub fn saveReport(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: equiGavinFetchActorSuccess
+#[allow(non_snake_case)]
 pub fn equiGavinFetchActorSuccess(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: CheckingGavUnionExit
+#[allow(non_snake_case)]
 pub fn CheckingGavUnionExit(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: gavUnionDBActorSuccess
+#[allow(non_snake_case)]
 pub fn gavUnionDBActorSuccess(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: FetchingCompleteEntryAction
+#[allow(non_snake_case)]
 pub fn FetchingCompleteEntryAction(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: gavUnionFetchActorSuccess
+#[allow(non_snake_case)]
 pub fn gavUnionFetchActorSuccess(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: CheckingGavperianEntry
+#[allow(non_snake_case)]
 pub fn CheckingGavperianEntry(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: gavperianCheckActorSuccess
+#[allow(non_snake_case)]
 pub fn gavperianCheckActorSuccess(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: checkGavPerianActorSuccess
+#[allow(non_snake_case)]
 pub fn checkGavPerianActorSuccess(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: saveCreditProfile
+#[allow(non_snake_case)]
 pub fn saveCreditProfile(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: generateInterestRatesSuccess
+#[allow(non_snake_case)]
 pub fn generateInterestRatesSuccess(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: emailUser
+#[allow(non_snake_case)]
 pub fn emailUser(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: emailSalesTeam
+#[allow(non_snake_case)]
 pub fn emailSalesTeam(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: allWorkflowStepDoneEntryAction
+#[allow(non_snake_case)]
 pub fn allWorkflowStepDoneEntryAction(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }

--- a/apps/fsm-core-example/fsm/creditCheck/v02/rust/delays/mod.rs
+++ b/apps/fsm-core-example/fsm/creditCheck/v02/rust/delays/mod.rs
@@ -1,28 +1,33 @@
 // Delay: 111111
+#[allow(non_snake_case)]
 pub fn delay111111(context: &serde_json::Value, event: &serde_json::Value) -> u64 {
     // TODO: implement delay logic (return ms)
     0
 }
 
 // Delay: short1000delay
+#[allow(non_snake_case)]
 pub fn delayshort1000delay(context: &serde_json::Value, event: &serde_json::Value) -> u64 {
     // TODO: implement delay logic (return ms)
     0
 }
 
 // Delay: logng2000delay
+#[allow(non_snake_case)]
 pub fn delaylogng2000delay(context: &serde_json::Value, event: &serde_json::Value) -> u64 {
     // TODO: implement delay logic (return ms)
     0
 }
 
 // Delay: vc1000delay
+#[allow(non_snake_case)]
 pub fn delayvc1000delay(context: &serde_json::Value, event: &serde_json::Value) -> u64 {
     // TODO: implement delay logic (return ms)
     0
 }
 
 // Delay: vc2000delay
+#[allow(non_snake_case)]
 pub fn delayvc2000delay(context: &serde_json::Value, event: &serde_json::Value) -> u64 {
     // TODO: implement delay logic (return ms)
     0

--- a/apps/fsm-core-example/fsm/taskMachineConfig/v01/rust/actions/mod.rs
+++ b/apps/fsm-core-example/fsm/taskMachineConfig/v01/rust/actions/mod.rs
@@ -1,9 +1,11 @@
 // Action: assignTasks
+#[allow(non_snake_case)]
 pub fn assignTasks(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignError
+#[allow(non_snake_case)]
 pub fn assignError(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }

--- a/apps/fsm-core-example/fsm/taskMachineConfig/v02/rust/actions/mod.rs
+++ b/apps/fsm-core-example/fsm/taskMachineConfig/v02/rust/actions/mod.rs
@@ -1,9 +1,11 @@
 // Action: assignTasksupdate
+#[allow(non_snake_case)]
 pub fn assignTasksupdate(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }
 
 // Action: assignError
+#[allow(non_snake_case)]
 pub fn assignError(context: &serde_json::Value, event: &serde_json::Value) {
     // TODO: implement
 }

--- a/packages/fsm-compiler-ts/src/operation-logic-scaffold.ts
+++ b/packages/fsm-compiler-ts/src/operation-logic-scaffold.ts
@@ -218,7 +218,7 @@ function actorsBarrelEntry(
     case "python":
       return `from .${fileBaseName}.${fileBaseName} import ${src}`;
     case "rust":
-      return `#[path = "${fileBaseName}/${fileBaseName}.rs"]\nmod ${fileBaseName};\npub use ${fileBaseName}::${src};`;
+      return `#[path = "${fileBaseName}/${fileBaseName}.rs"]\n#[allow(non_snake_case)]\nmod ${fileBaseName};\npub use ${fileBaseName}::${src};`;
   }
 }
 

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actions.eta
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actions.eta
@@ -1,4 +1,5 @@
 // <%~ it.label %>: <%~ it.name %>
+#[allow(non_snake_case)]
 pub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) {
     // <%~ it.todo %>
 }

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actions.generated.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actions.generated.ts
@@ -4,7 +4,7 @@ import { eta } from "../eta-instance.ts";
 import type { TemplateFn } from "../../types.ts";
 
 const compiled = eta.compile(
-  "// <%~ it.label %>: <%~ it.name %>\npub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) {\n    // <%~ it.todo %>\n}\n\n",
+  "// <%~ it.label %>: <%~ it.name %>\n#[allow(non_snake_case)]\npub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) {\n    // <%~ it.todo %>\n}\n\n",
 );
 
 export const render: TemplateFn = (input) => compiled.call(eta, input);

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actors.eta
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actors.eta
@@ -1,4 +1,5 @@
 // <%~ it.label %>: <%~ it.name %>
+#[allow(non_snake_case)]
 pub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) {
     // <%~ it.todo %>
 }

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actors.generated.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actors.generated.ts
@@ -4,7 +4,7 @@ import { eta } from "../eta-instance.ts";
 import type { TemplateFn } from "../../types.ts";
 
 const compiled = eta.compile(
-  "// <%~ it.label %>: <%~ it.name %>\npub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) {\n    // <%~ it.todo %>\n}\n\n",
+  "// <%~ it.label %>: <%~ it.name %>\n#[allow(non_snake_case)]\npub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) {\n    // <%~ it.todo %>\n}\n\n",
 );
 
 export const render: TemplateFn = (input) => compiled.call(eta, input);

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/delays.eta
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/delays.eta
@@ -1,4 +1,5 @@
 // <%~ it.label %>: <%~ it.name %>
+#[allow(non_snake_case)]
 pub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) -> u64 {
     // <%~ it.todo %>
     0

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/delays.generated.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/delays.generated.ts
@@ -4,7 +4,7 @@ import { eta } from "../eta-instance.ts";
 import type { TemplateFn } from "../../types.ts";
 
 const compiled = eta.compile(
-  "// <%~ it.label %>: <%~ it.name %>\npub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) -> u64 {\n    // <%~ it.todo %>\n    0\n}\n\n",
+  "// <%~ it.label %>: <%~ it.name %>\n#[allow(non_snake_case)]\npub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) -> u64 {\n    // <%~ it.todo %>\n    0\n}\n\n",
 );
 
 export const render: TemplateFn = (input) => compiled.call(eta, input);

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/guards.eta
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/guards.eta
@@ -1,4 +1,5 @@
 // <%~ it.label %>: <%~ it.name %>
+#[allow(non_snake_case)]
 pub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) -> bool {
     // <%~ it.todo %>
     true

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/guards.generated.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/guards.generated.ts
@@ -4,7 +4,7 @@ import { eta } from "../eta-instance.ts";
 import type { TemplateFn } from "../../types.ts";
 
 const compiled = eta.compile(
-  "// <%~ it.label %>: <%~ it.name %>\npub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) -> bool {\n    // <%~ it.todo %>\n    true\n}\n\n",
+  "// <%~ it.label %>: <%~ it.name %>\n#[allow(non_snake_case)]\npub fn <%~ it.fnName %>(context: &serde_json::Value, event: &serde_json::Value) -> bool {\n    // <%~ it.todo %>\n    true\n}\n\n",
 );
 
 export const render: TemplateFn = (input) => compiled.call(eta, input);

--- a/packages/fsm-compiler-ts/test/operation-logic-scaffold.test.ts
+++ b/packages/fsm-compiler-ts/test/operation-logic-scaffold.test.ts
@@ -87,28 +87,28 @@ const cases: Case[] = [
     kind: "actions",
     name: "sendEmail",
     expected:
-      "// Action: sendEmail\npub fn sendEmail(context: &serde_json::Value, event: &serde_json::Value) {\n    // TODO: implement\n}\n",
+      "// Action: sendEmail\n#[allow(non_snake_case)]\npub fn sendEmail(context: &serde_json::Value, event: &serde_json::Value) {\n    // TODO: implement\n}\n",
   },
   {
     lang: "rust",
     kind: "guards",
     name: "isEligible",
     expected:
-      "// Guard: isEligible\npub fn isEligible(context: &serde_json::Value, event: &serde_json::Value) -> bool {\n    // TODO: implement\n    true\n}\n",
+      "// Guard: isEligible\n#[allow(non_snake_case)]\npub fn isEligible(context: &serde_json::Value, event: &serde_json::Value) -> bool {\n    // TODO: implement\n    true\n}\n",
   },
   {
     lang: "rust",
     kind: "delays",
     name: "cooldown",
     expected:
-      "// Delay: cooldown\npub fn delaycooldown(context: &serde_json::Value, event: &serde_json::Value) -> u64 {\n    // TODO: implement delay logic (return ms)\n    0\n}\n",
+      "// Delay: cooldown\n#[allow(non_snake_case)]\npub fn delaycooldown(context: &serde_json::Value, event: &serde_json::Value) -> u64 {\n    // TODO: implement delay logic (return ms)\n    0\n}\n",
   },
   {
     lang: "rust",
     kind: "actors",
     name: "creditCheck",
     expected:
-      "// Actor: creditCheck\npub fn creditCheck(context: &serde_json::Value, event: &serde_json::Value) {\n    // TODO: implement actor logic\n}\n",
+      "// Actor: creditCheck\n#[allow(non_snake_case)]\npub fn creditCheck(context: &serde_json::Value, event: &serde_json::Value) {\n    // TODO: implement actor logic\n}\n",
   },
   // go (renderOperationModule prefixes the `package <kind>` header — accounted
   // for separately below, these cases cover the per-name stub only)
@@ -298,6 +298,7 @@ Deno.test("writeActorsBarrel - rust writes a mod.rs with #[path] attributes", as
     assertEquals(
       content,
       '#[path = "checkBureau/checkBureau.rs"]\n' +
+        "#[allow(non_snake_case)]\n" +
         "mod checkBureau;\n" +
         "pub use checkBureau::checkBureau;\n",
     );


### PR DESCRIPTION
## Summary
- Adds `#[allow(non_snake_case)]` to every generated Rust `pub fn` (actions/guards/delays/actors) and to the `mod <name>;` declaration in the generated `rust/actors/mod.rs` barrel, since Rust stub names come verbatim from the FSM's `src` (typically camelCase) to stay consistent with every other generated language.
- Verified with a real `cargo check` against a temp crate with `serde_json`: 0 `non_snake_case` warnings now (only the pre-existing, unrelated `unused_variables` warnings on the empty stub bodies remain).
- Chosen over renaming to snake_case (the other option originally recorded in this issue) so the same `src` string identifies the same function across every generated language, with no per-language name-mapping needed later.
- Regenerated every Rust file under `apps/fsm-core-example/fsm` accordingly.

#78 originally covered both Go and Rust naming gaps; split so this PR can close a well-scoped issue — Go's half (exported-name + unknown Go-module-path blockers) is now tracked separately in #83.

Closes #78

## Test plan
- [x] Regression suite (40 tests) passing, including updated expected strings for all 4 Rust `(kind)` templates and the Rust barrel.
- [x] `deno fmt --check` clean across the compiler source and the regenerated example fixtures.
- [x] `deno check` clean on the regenerated `.generated.ts` template modules.
- [x] Real `cargo check` (0 errors, 0 `non_snake_case` warnings) against a temp crate wrapping the regenerated `rust/actors/` tree with `serde_json` as an actual dependency.