### PR TITLE
feat(compiler): scaffolded actors return input + lang-invocation msg

### DIFF
--- a/packages/fsm-compiler-ts/src/scaffold-templates/derive-template-input.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/derive-template-input.ts
@@ -7,8 +7,9 @@ import type { TemplateInput } from "./types.ts";
 
 /**
  * Derives the values every template needs from a `(kind, name, lang)` triple.
- * `lang` only matters for Go actors (see {@linkcode toGoExportedName}) —
- * every other combination ignores it.
+ * `lang` renames the exported symbol for Go actors (see
+ * {@linkcode toGoExportedName}) and is passed through as-is for every actor
+ * template's invoked-by message; every other kind ignores it.
  */
 export function deriveTemplateInput(
   kind: OperationKind,
@@ -30,5 +31,5 @@ export function deriveTemplateInput(
     ? "TODO: implement delay logic (return ms)"
     : "TODO: implement";
 
-  return { name, fnName, label, todo };
+  return { name, fnName, label, todo, lang };
 }

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/go/actors.eta
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/go/actors.eta
@@ -1,6 +1,6 @@
 // <%~ it.label %>: <%~ it.name %>
 func <%~ it.fnName %>(input any) (any, error) {
 	// <%~ it.todo %>
-	return map[string]any{}, nil
+	return map[string]any{"input": input, "msg": "<%~ it.name %> actor invoked by <%~ it.lang %>"}, nil
 }
 

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/go/actors.generated.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/go/actors.generated.ts
@@ -3,7 +3,7 @@
 import { eta } from "../eta-instance.ts";
 
 const compiled = eta.compile(
-  "// <%~ it.label %>: <%~ it.name %>\nfunc <%~ it.fnName %>(input any) (any, error) {\n\t// <%~ it.todo %>\n\treturn map[string]any{}, nil\n}\n\n",
+  '// <%~ it.label %>: <%~ it.name %>\nfunc <%~ it.fnName %>(input any) (any, error) {\n\t// <%~ it.todo %>\n\treturn map[string]any{"input": input, "msg": "<%~ it.name %> actor invoked by <%~ it.lang %>"}, nil\n}\n\n',
 );
 
 export const render: (input: unknown) => string = (input) =>

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/python/actors.eta
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/python/actors.eta
@@ -1,5 +1,5 @@
 # <%~ it.label %>: <%~ it.name %>
 def <%~ it.fnName %>(input):
     # <%~ it.todo %>
-    return {}
+    return {"input": input, "msg": "<%~ it.name %> actor invoked by <%~ it.lang %>"}
 

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/python/actors.generated.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/python/actors.generated.ts
@@ -3,7 +3,7 @@
 import { eta } from "../eta-instance.ts";
 
 const compiled = eta.compile(
-  "# <%~ it.label %>: <%~ it.name %>\ndef <%~ it.fnName %>(input):\n    # <%~ it.todo %>\n    return {}\n\n",
+  '# <%~ it.label %>: <%~ it.name %>\ndef <%~ it.fnName %>(input):\n    # <%~ it.todo %>\n    return {"input": input, "msg": "<%~ it.name %> actor invoked by <%~ it.lang %>"}\n\n',
 );
 
 export const render: (input: unknown) => string = (input) =>

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actors.eta
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actors.eta
@@ -2,6 +2,6 @@
 #[allow(non_snake_case)]
 pub fn <%~ it.fnName %>(input: serde_json::Value) -> serde_json::Value {
     // <%~ it.todo %>
-    serde_json::json!({})
+    serde_json::json!({ "input": input, "msg": "<%~ it.name %> actor invoked by <%~ it.lang %>" })
 }
 

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actors.generated.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/rust/actors.generated.ts
@@ -3,7 +3,7 @@
 import { eta } from "../eta-instance.ts";
 
 const compiled = eta.compile(
-  "// <%~ it.label %>: <%~ it.name %>\n#[allow(non_snake_case)]\npub fn <%~ it.fnName %>(input: serde_json::Value) -> serde_json::Value {\n    // <%~ it.todo %>\n    serde_json::json!({})\n}\n\n",
+  '// <%~ it.label %>: <%~ it.name %>\n#[allow(non_snake_case)]\npub fn <%~ it.fnName %>(input: serde_json::Value) -> serde_json::Value {\n    // <%~ it.todo %>\n    serde_json::json!({ "input": input, "msg": "<%~ it.name %> actor invoked by <%~ it.lang %>" })\n}\n\n',
 );
 
 export const render: (input: unknown) => string = (input) =>

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/typescript/actors.eta
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/typescript/actors.eta
@@ -1,6 +1,6 @@
 // <%~ it.label %>: <%~ it.name %>
 export function <%~ it.fnName %>(input: unknown): unknown {
   // <%~ it.todo %>
-  return {};
+  return { input, msg: "<%~ it.name %> actor invoked by <%~ it.lang %>" };
 }
 

--- a/packages/fsm-compiler-ts/src/scaffold-templates/eta/typescript/actors.generated.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/eta/typescript/actors.generated.ts
@@ -3,7 +3,7 @@
 import { eta } from "../eta-instance.ts";
 
 const compiled = eta.compile(
-  "// <%~ it.label %>: <%~ it.name %>\nexport function <%~ it.fnName %>(input: unknown): unknown {\n  // <%~ it.todo %>\n  return {};\n}\n\n",
+  '// <%~ it.label %>: <%~ it.name %>\nexport function <%~ it.fnName %>(input: unknown): unknown {\n  // <%~ it.todo %>\n  return { input, msg: "<%~ it.name %> actor invoked by <%~ it.lang %>" };\n}\n\n',
 );
 
 export const render: (input: unknown) => string = (input) =>

--- a/packages/fsm-compiler-ts/src/scaffold-templates/types.ts
+++ b/packages/fsm-compiler-ts/src/scaffold-templates/types.ts
@@ -1,11 +1,15 @@
-import type { OperationKind } from "../operation-logic-scaffold.ts";
+import type {
+  OperationKind,
+  OperationLang,
+} from "../operation-logic-scaffold.ts";
 
-/** Values derived from a `(kind, name)` pair, passed to every template function. */
+/** Values derived from a `(kind, name, lang)` triple, passed to every template function. */
 export type TemplateInput = {
   name: string;
   fnName: string;
   label: string;
   todo: string;
+  lang: OperationLang;
 };
 
 /** Renders one operation-logic stub for a given kind. */

--- a/packages/fsm-compiler-ts/test/create-async-logic.test.ts
+++ b/packages/fsm-compiler-ts/test/create-async-logic.test.ts
@@ -17,7 +17,7 @@ Deno.test("createAsyncOperationLogic - writes a single actor under <appRoot>/sha
     const content = await Deno.readTextFile(file);
     assertEquals(
       content,
-      "// Actor: checkCreditScore\nexport function checkCreditScore(input: unknown): unknown {\n  // TODO: implement actor logic\n  return {};\n}\n",
+      '// Actor: checkCreditScore\nexport function checkCreditScore(input: unknown): unknown {\n  // TODO: implement actor logic\n  return { input, msg: "checkCreditScore actor invoked by typescript" };\n}\n',
     );
   } finally {
     await Deno.remove(dir, { recursive: true });

--- a/packages/fsm-compiler-ts/test/operation-logic-scaffold.test.ts
+++ b/packages/fsm-compiler-ts/test/operation-logic-scaffold.test.ts
@@ -56,7 +56,7 @@ const cases: Case[] = [
     kind: "actors",
     name: "creditCheck",
     expected:
-      "// Actor: creditCheck\nexport function creditCheck(input: unknown): unknown {\n  // TODO: implement actor logic\n  return {};\n}\n",
+      '// Actor: creditCheck\nexport function creditCheck(input: unknown): unknown {\n  // TODO: implement actor logic\n  return { input, msg: "creditCheck actor invoked by typescript" };\n}\n',
   },
   // python
   {
@@ -85,7 +85,7 @@ const cases: Case[] = [
     kind: "actors",
     name: "creditCheck",
     expected:
-      "# Actor: creditCheck\ndef creditCheck(input):\n    # TODO: implement actor logic\n    return {}\n",
+      '# Actor: creditCheck\ndef creditCheck(input):\n    # TODO: implement actor logic\n    return {"input": input, "msg": "creditCheck actor invoked by python"}\n',
   },
   // rust
   {
@@ -114,7 +114,7 @@ const cases: Case[] = [
     kind: "actors",
     name: "creditCheck",
     expected:
-      "// Actor: creditCheck\n#[allow(non_snake_case)]\npub fn creditCheck(input: serde_json::Value) -> serde_json::Value {\n    // TODO: implement actor logic\n    serde_json::json!({})\n}\n",
+      '// Actor: creditCheck\n#[allow(non_snake_case)]\npub fn creditCheck(input: serde_json::Value) -> serde_json::Value {\n    // TODO: implement actor logic\n    serde_json::json!({ "input": input, "msg": "creditCheck actor invoked by rust" })\n}\n',
   },
   // go (renderOperationModule prefixes the `package <kind>` header — accounted
   // for separately below, these cases cover the per-name stub only)
@@ -146,7 +146,7 @@ const cases: Case[] = [
     expected:
       // Go exports (capitalizes) actor function names for cross-package
       // access — see toGoExportedName / #83. Other kinds/languages don't.
-      "// Actor: creditCheck\nfunc CreditCheck(input any) (any, error) {\n\t// TODO: implement actor logic\n\treturn map[string]any{}, nil\n}\n",
+      '// Actor: creditCheck\nfunc CreditCheck(input any) (any, error) {\n\t// TODO: implement actor logic\n\treturn map[string]any{"input": input, "msg": "creditCheck actor invoked by go"}, nil\n}\n',
   },
 ];
 
@@ -182,7 +182,7 @@ Deno.test("writeActorFile - go actor gets a package header, exported (capitalize
     const content = await Deno.readTextFile(file);
     assertEquals(
       content,
-      "package actors\n\n// Actor: creditCheck\nfunc CreditCheck(input any) (any, error) {\n\t// TODO: implement actor logic\n\treturn map[string]any{}, nil\n}\n",
+      'package actors\n\n// Actor: creditCheck\nfunc CreditCheck(input any) (any, error) {\n\t// TODO: implement actor logic\n\treturn map[string]any{"input": input, "msg": "creditCheck actor invoked by go"}, nil\n}\n',
     );
   } finally {
     await Deno.remove(dir, { recursive: true });
@@ -238,7 +238,7 @@ Deno.test("writeActorFile - typescript actor has no package header", async () =>
     const content = await Deno.readTextFile(file);
     assertEquals(
       content,
-      "// Actor: creditCheck\nexport function creditCheck(input: unknown): unknown {\n  // TODO: implement actor logic\n  return {};\n}\n",
+      '// Actor: creditCheck\nexport function creditCheck(input: unknown): unknown {\n  // TODO: implement actor logic\n  return { input, msg: "creditCheck actor invoked by typescript" };\n}\n',
     );
   } finally {
     await Deno.remove(dir, { recursive: true });


### PR DESCRIPTION
## Summary
- All four `actors.eta` scaffold templates (typescript/python/rust/go) now return `{ input, msg: "<name> actor invoked by <lang>" }` instead of an empty object, so a scaffolded actor's default response carries the input forward and identifies which language ran it.
- `TemplateInput` gains a `lang` field (threaded through `deriveTemplateInput`) so every actor template can name its own language.
- `.generated.ts` files regenerated via `deno task generate:templates` + `deno fmt`.
- Updated `operation-logic-scaffold.test.ts` / `create-async-logic.test.ts` expectations to match.

Closes #123

## Test plan
- [x] `deno test --allow-all test/operation-logic-scaffold.test.ts test/create-async-logic.test.ts` — 48 passed
- [x] `deno check` on touched source files
- [x] `deno fmt --check` clean
- [x] Confirmed the 12 pre-existing `cli.test.ts` failures (stderr polluted by an unrelated npm workspace warning) also fail on `main`, unaffected by this change