### PR TITLE
fix(compiler): run cli/generate-fsm-json integration tests against a temp copy

### DIFF
--- a/packages/fsm-compiler-ts/deno.json
+++ b/packages/fsm-compiler-ts/deno.json
@@ -19,6 +19,7 @@
     "@deno/dnt": "jsr:@deno/dnt@^0.43.0",
     "@std/assert": "jsr:@std/assert@1",
     "@std/cli": "jsr:@std/cli@1",
+    "@std/fs": "jsr:@std/fs@1",
     "eta": "jsr:@eta-dev/eta@^3.5.0",
     "@types/pg": "npm:@types/pg@^8.18.0",
     "ajv": "npm:ajv@^8.18.0",

--- a/packages/fsm-compiler-ts/test/cli.test.ts
+++ b/packages/fsm-compiler-ts/test/cli.test.ts
@@ -1,8 +1,18 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { copy } from "@std/fs/copy";
 
 const CLI = "packages/fsm-compiler-ts/src/cli/index.ts";
-const FSM_FOLDER = "apps/fsm-core-example/fsm";
-const SHARED_FSM_FOLDER = "apps/fsm-core-example/sharedFSM";
+
+// generate/delete/create-async-logic below invoke the real CLI as a
+// subprocess against these paths, so they must never point at the tracked
+// apps/fsm-core-example — that would delete/regenerate real committed files
+// (see #125). Work on a disposable copy instead, cleaned up by the final
+// test in this file.
+const FIXTURE_ROOT = await Deno.makeTempDir({ prefix: "fsm-compiler-cli-" });
+const APP_ROOT = `${FIXTURE_ROOT}/fsm-core-example`;
+await copy("apps/fsm-core-example", APP_ROOT);
+const FSM_FOLDER = `${APP_ROOT}/fsm`;
+const SHARED_FSM_FOLDER = `${APP_ROOT}/sharedFSM`;
 
 async function runCli(
   args: string[],
@@ -182,7 +192,7 @@ Deno.test("cli create-async-logic without --version exits 1", async () => {
     "-c",
     "create-async-logic",
     "-f",
-    "apps/fsm-core-example",
+    APP_ROOT,
     "--lang",
     "typescript",
     "--name",
@@ -197,7 +207,7 @@ Deno.test("cli create-async-logic without --name exits 1", async () => {
     "-c",
     "create-async-logic",
     "-f",
-    "apps/fsm-core-example",
+    APP_ROOT,
     "--lang",
     "typescript",
     "--version",
@@ -212,7 +222,7 @@ Deno.test("cli create-async-logic rejects an invalid --lang", async () => {
     "-c",
     "create-async-logic",
     "-f",
-    "apps/fsm-core-example",
+    APP_ROOT,
     "--lang",
     "cobol",
     "--version",
@@ -229,7 +239,7 @@ Deno.test("cli create-async-logic rejects a comma-separated --lang (exactly one 
     "-c",
     "create-async-logic",
     "-f",
-    "apps/fsm-core-example",
+    APP_ROOT,
     "--lang",
     "typescript,python",
     "--version",
@@ -242,30 +252,23 @@ Deno.test("cli create-async-logic rejects a comma-separated --lang (exactly one 
 });
 
 Deno.test("cli create-async-logic writes a single actor file under shared-async-op", async () => {
-  const actorFile =
-    "apps/fsm-core-example/shared-async-op/v01/typescript/actors/checkCreditScoreCliTest/checkCreditScoreCliTest.ts";
-  try {
-    const { code } = await runCli([
-      "-c",
-      "create-async-logic",
-      "-f",
-      "apps/fsm-core-example",
-      "--lang",
-      "typescript",
-      "--version",
-      "v01",
-      "--name",
-      "checkCreditScoreCliTest",
-    ]);
-    assertEquals(code, 0);
-    const stat = await Deno.stat(actorFile);
-    assertEquals(stat.isFile, true);
-  } finally {
-    await Deno.remove(
-      "apps/fsm-core-example/shared-async-op/v01/typescript/actors/checkCreditScoreCliTest",
-      { recursive: true },
-    ).catch(() => {});
-  }
+  const { code } = await runCli([
+    "-c",
+    "create-async-logic",
+    "-f",
+    APP_ROOT,
+    "--lang",
+    "typescript",
+    "--version",
+    "v01",
+    "--name",
+    "checkCreditScoreCliTest",
+  ]);
+  assertEquals(code, 0);
+  const stat = await Deno.stat(
+    `${APP_ROOT}/shared-async-op/v01/typescript/actors/checkCreditScoreCliTest/checkCreditScoreCliTest.ts`,
+  );
+  assertEquals(stat.isFile, true);
 });
 
 // --- delete ---
@@ -380,4 +383,12 @@ Deno.test("cli --available-actors flag is accepted", async () => {
   } finally {
     await Deno.remove(tmpFile);
   }
+});
+
+// --- Cleanup ---
+// Deno runs tests within a file sequentially in declaration order (absent
+// --parallel), so this runs last and removes the fixture copy every prior
+// test in this file wrote into.
+Deno.test("cleanup fixture copy", async () => {
+  await Deno.remove(FIXTURE_ROOT, { recursive: true });
 });

--- a/packages/fsm-compiler-ts/test/generate-fsm-json.test.ts
+++ b/packages/fsm-compiler-ts/test/generate-fsm-json.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertExists } from "@std/assert";
+import { copy } from "@std/fs/copy";
 import {
   addMissingFsmTypeToInvokeActors,
   type FsmDraftStateNode,
@@ -210,9 +211,17 @@ Deno.test("normalizeActionsToObjects - does not mutate original", () => {
 });
 
 // --- generateFsmJSONFromFolders integration tests ---
+// generateFsmJSONFromFolders writes fsm.json/xstate-fsm.json in place, so
+// these must run against a disposable copy, never the tracked
+// apps/fsm-core-example (see #125).
 
-const FSM_FOLDER = "apps/fsm-core-example/fsm";
-const SHARED_FSM_FOLDER = "apps/fsm-core-example/sharedFSM";
+const FIXTURE_ROOT = await Deno.makeTempDir({
+  prefix: "fsm-compiler-generate-fsm-json-",
+});
+const APP_ROOT = `${FIXTURE_ROOT}/fsm-core-example`;
+await copy("apps/fsm-core-example", APP_ROOT);
+const FSM_FOLDER = `${APP_ROOT}/fsm`;
+const SHARED_FSM_FOLDER = `${APP_ROOT}/sharedFSM`;
 
 Deno.test("generateFsmJSONFromFolders - generates fsm.json for fsm folder", async () => {
   await generateFsmJSONFromFolders(FSM_FOLDER, "fsm", []);
@@ -269,4 +278,12 @@ Deno.test("generateFsmJSONFromFolders - throws on path ending with '/'", async (
     assertExists((e as Error).message.match(/cannot end with/i));
   }
   assertEquals(threw, true);
+});
+
+// --- Cleanup ---
+// Deno runs tests within a file sequentially in declaration order (absent
+// --parallel), so this runs last and removes the fixture copy every prior
+// test in this file wrote into.
+Deno.test("cleanup fixture copy", async () => {
+  await Deno.remove(FIXTURE_ROOT, { recursive: true });
 });


### PR DESCRIPTION
## Summary
- `cli.test.ts` and `generate-fsm-json.test.ts` pointed `FSM_FOLDER`/`SHARED_FSM_FOLDER` (and `create-async-logic`'s app-root arg) directly at the tracked `apps/fsm-core-example` tree. Running the suite invoked real `generate`/`delete`/`create-async-logic` CLI subcommands and `generateFsmJSONFromFolders` against those paths, mutating and deleting committed fixture files.
- Both files now copy `apps/fsm-core-example` into a fresh `Deno.makeTempDir()` up front (via `@std/fs`'s `copy`) and point every test at that copy, with a trailing `cleanup fixture copy` test removing the temp dir once the file's tests finish (Deno runs a file's tests sequentially in declaration order, so this reliably runs last).
- `operation-logic-scaffold.test.ts` and `create-async-logic.test.ts` already used `Deno.makeTempDir()` correctly and needed no changes.

Closes #125

## Test plan
- [x] `deno test --allow-all packages/fsm-compiler-ts/test/` run from repo root — 102 passed, 12 failed (same pre-existing failures as on `main`, unrelated stderr-pollution from an npm workspace warning — see PR #124's test plan)
- [x] `git status` clean under `apps/fsm-core-example/` after the run (previously ~74 files modified/deleted)
- [x] `deno fmt --check` / `deno check` clean on touched files