### PR TITLE
chore(examples): move async-worker fleet test into own subfolder

### DIFF
--- a/apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v1/fsm-core-xstate-fleet-journey-test.ts
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v1/fsm-core-xstate-fleet-journey-test.ts
@@ -3,7 +3,7 @@ import { diff } from "json-diff-ts";
 import { assertEquals } from "@std/assert";
 import { Pool } from "pg";
 
-import { machineWithProvider } from "./machine-with-provider.ts";
+import { machineWithProvider } from "../machine-with-provider.ts";
 import { runFsmScheduler, startFsmlet } from "@pgfsm/sync-worker";
 import type { FsmletHandle } from "@pgfsm/sync-worker";
 import {
@@ -25,7 +25,7 @@ const fsm_version = "v01";
 
 // validateSyncOperationFromFolders / validateAsyncOperationFromFolders expect
 // the *parent* of per-FSM folders (e.g. ".../fsm", containing "creditCheck/v01").
-const FSM_FOLDER_PATH = import.meta.dirname!.split("/").slice(0, -2).join("/");
+const FSM_FOLDER_PATH = import.meta.dirname!.split("/").slice(0, -3).join("/");
 const SKIP_DIRS = ["carVitals", "taskMachineConfig"];
 
 const SUBMIT_EVENT = {


### PR DESCRIPTION
## Summary
- fsm-core-xstate-fleet-journey-test.ts is the only test in `creditCheck/v01` that exercises the full bounded-fleet stack including `@pgfsm/async-worker` (asyncOperationScheduler + asyncOperationWorkerlet), unlike the sibling tests in that folder which only compare fsm-compiler/xstate resolve output.
- Moved it to `creditCheck/v01/test-with-async-worker-v1/fsm-core-xstate-fleet-journey-test.ts` to make that dependency explicit in the directory layout, and fixed its relative import + `FSM_FOLDER_PATH` dirname-slice depth for the new nesting level.

Closes #146

## Test plan
- [x] `deno test --allow-all --no-check --env-file=.env apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v1/fsm-core-xstate-fleet-journey-test.ts` against local Supabase — 3 passed, 0 failed
- Note: `--no-check` needed due to a pre-existing, unrelated type error in `packages/fsm-sync-worker-ts/src/fsmlet/fsmlet.ts` (ActorReference vs AsyncActor `fsmVersion` optionality) — not introduced by this change, not currently caught by CI's `deno test` invocation.