### PR TITLE
fix(worker-queue): align promise-actor queue naming between fsmlet and async-op-worker-gateway

### DIFF
--- a/packages/database-src/database.types.ts
+++ b/packages/database-src/database.types.ts
@@ -830,6 +830,7 @@ export type Database = {
           event_input: Json;
           event_name: string;
           from_source_fsm_instance_id: string;
+          fsmlanguage: string;
           fsmname: string;
           fsmtype: string;
           fsmversion: string;
@@ -1362,6 +1363,7 @@ export type Database = {
           event_input: Json;
           event_name: string;
           from_source_fsm_instance_id: string;
+          fsmlanguage: string;
           fsmname: string;
           fsmtype: string;
           fsmversion: string;

--- a/packages/database-src/supabase/migrations/20260818095023_fsm_core--2.0.1--2.0.2.sql
+++ b/packages/database-src/supabase/migrations/20260818095023_fsm_core--2.0.1--2.0.2.sql
@@ -1,38 +1,13 @@
--- ============================================================
--- 1. create_promise_queue_and_send_event_from_fsm_instance_id_v2 (renamed)
---    Routes promise/sharedPromise events to promise queue.
---    Checks queue existence, creates if missing, returns send result.
--- ============================================================
-DROP FUNCTION IF EXISTS fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(text, jsonb, text, text, text, text, text, text, text, text, uuid);
--- Queue naming delegates to fsm_core.compute_promise_queue_name_v2
--- (30_async_operation_worker_v2/20260806201803_ensure_promise_queue_for_worker.sql,
--- loaded before this file) instead of computing it inline, so this function
--- and fsm-core-async-op-worker's poll loop (claim_pending_promise_events_for_workers_v2,
--- same shared helper) can never drift onto different queue names for the
--- same actor identity again. fsmLanguage is a new parameter this call needs
--- to pass through -- the compiled FSM's invoke action params already carry
--- it (see fsm.json), archive_event_from_fsm_type_worker_v2 just wasn't
--- reading it yet.
---
--- compute_promise_queue_name_v2 has no fsmType validation of its own (its
--- "otherwise" branch happily names a queue for any fsmType, not just
--- 'sharedPromise') -- this function still validates fsmType itself, same as
--- before, so an unsupported fsmType keeps raising here rather than silently
--- getting a queue name and proceeding.
-CREATE OR REPLACE FUNCTION fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(
-    event_name text,
-    event_input jsonb,
-    id text,
-    action_type text,
-    src text,
-    fsmName text,
-    fsmType text,
-    fsmVersion text,
-    parentFsmName text,
-    parentFsmVersion text,
-    fsmLanguage text,
-    from_source_fsm_instance_id uuid
-) RETURNS jsonb AS $$
+drop function if exists "fsm_core"."create_promise_queue_and_send_event_from_fsm_instance_id_v2"(event_name text, event_input jsonb, id text, action_type text, src text, fsmname text, fsmtype text, fsmversion text, parentfsmname text, parentfsmversion text, from_source_fsm_instance_id uuid);
+
+drop function if exists "fsm_core"."send_event_to_queue_from_fsm_instance_id_v2"(event_name text, event_input jsonb, id text, action_type text, src text, fsmname text, fsmtype text, fsmversion text, parentfsmname text, parentfsmversion text, from_source_fsm_instance_id uuid);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(event_name text, event_input jsonb, id text, action_type text, src text, fsmname text, fsmtype text, fsmversion text, parentfsmname text, parentfsmversion text, fsmlanguage text, from_source_fsm_instance_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
 DECLARE
     promise_queue_name text;
     queue_exists boolean := false;
@@ -75,75 +50,13 @@ BEGIN
 
     RETURN send_result || jsonb_build_object('start_queue_worker', start_queue_worker);
 END;
-$$ LANGUAGE plpgsql;
+$function$
+;
 
-
--- ============================================================
--- 2. create_fsm_queue_and_send_event_from_fsm_instance_id_v2 (renamed)
---    Routes childFsm events: generates UUID child queue,
---    creates it, sends event, returns send result.
--- ============================================================
-DROP FUNCTION IF EXISTS fsm_core.create_fsm_queue_and_send_event_from_fsm_instance_id_v2(text, jsonb, text, text, text, text, text, text, text, text, uuid);
-CREATE OR REPLACE FUNCTION fsm_core.create_fsm_queue_and_send_event_from_fsm_instance_id_v2(
-    event_name text,
-    event_input jsonb,
-    id text,
-    action_type text,
-    src text,
-    fsmName text,
-    fsmType text,
-    fsmVersion text,
-    parentFsmName text,
-    parentFsmVersion text,
-    from_source_fsm_instance_id uuid
-) RETURNS jsonb AS $$
-DECLARE
-    child_instance_id uuid := uuid_generate_v4();
-    send_result jsonb;
-BEGIN
-    PERFORM pgmq.create(queue_name := child_instance_id::text);
-
-    send_result := fsm_core.send_event_to_fsm_queue_with_event_logs_v2(
-        input_fsm_instance_id := child_instance_id,
-        input_fsm_instance_id_fsm_type := fsmType,
-        input_fsm_instance_id_fsm_version := fsmVersion,
-        input_send_to_parent_queue_id := from_source_fsm_instance_id,
-        input_send_to_parent_queue_type := 'FSM OR childFSM OR sharedFSM', -- # TODO : pending 
-        input_send_to_parent_queue_id_event_name := id,
-        input_event_name := event_name,
-        input_event_action_type := action_type,
-        input_event_data := event_input,
-        input_event_delay := 0,
-        input_event_status := 'fsm_started',
-        input_event_output := '{}'::jsonb,
-        input_error_message := NULL
-    );
-
-    RETURN send_result || jsonb_build_object('start_queue_worker', true, 'child_instance_id', child_instance_id);
-END;
-$$ LANGUAGE plpgsql;
-
-
--- ============================================================
--- 3. send_event_to_queue_from_fsm_instance_id_v2
---    Fix: pgmq.create (was fsm_core.create), real queue_exists check,
---         delegate to sub-functions, remove dead RETURN at end
--- ============================================================
-DROP FUNCTION IF EXISTS fsm_core.send_event_to_queue_from_fsm_instance_id_v2(text, jsonb, text, text, text, text, text, text, text, text, uuid);
-CREATE OR REPLACE FUNCTION fsm_core.send_event_to_queue_from_fsm_instance_id_v2(
-    event_name text,
-    event_input jsonb,
-    id text,
-    action_type text,
-    src text,
-    fsmName text,
-    fsmType text,
-    fsmVersion text,
-    parentFsmName text,
-    parentFsmVersion text,
-    fsmLanguage text,
-    from_source_fsm_instance_id uuid
-) RETURNS jsonb AS $$
+CREATE OR REPLACE FUNCTION fsm_core.send_event_to_queue_from_fsm_instance_id_v2(event_name text, event_input jsonb, id text, action_type text, src text, fsmname text, fsmtype text, fsmversion text, parentfsmname text, parentfsmversion text, fsmlanguage text, from_source_fsm_instance_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
 BEGIN
     IF fsmType = 'promise' OR fsmType = 'sharedPromise' THEN
         RETURN fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(
@@ -178,94 +91,13 @@ BEGIN
         RAISE EXCEPTION 'Unsupported fsmType: %', fsmType;
     END IF;
 END;
-$$ LANGUAGE plpgsql;
+$function$
+;
 
-
-
--- OLD structure for reference
-
--- to_be_removed_promise_queue_msg_ids example input:
--- [
---   {
---     id: "0.(machine).creditCheck.Verifying Credentials",
---     src: "verifyCredentials",
---     type: "xstate.invoke",
---     fsm_order: 3,
---     action_type: "invoke",
---   },
--- ]
-
--- input_total_promise_queue_data example input:
--- [
---   {
---     event: {
---       type: "promise",
---       event_data: null,
---       send_to_parent_queue_id: "5426d9c2-5c3f-49e7-ac1e-9388b659116f",
---       send_event_name_to_parent_queue_id: "0.(machine).creditCheck.Verifying Credentials",
---     },
---     queue_msg_id: 4,
---     promise_queue_name: "verifyCredentials",
---     start_promise_worker: true,
---   },
--- ]
-
-
--- NEW structure for reference
--- to_be_removed_promise_queue_msg_ids example input:
--- [
---     {
---       id: "0.(machine).creditCheck.Verifying Credentials",
---       src: "verifyCredentials",
---       type: "xstate.invoke",
---       fsmType: "promise",
---       fsm_order: 3,
---       fsmVersion: "v01",
---       action_type: "invoke"
---     }
--- ]
-
--- input_total_promise_queue_data example input:
--- [
---     {
---     queue_id: "creditCheck_v01_verifyCredentials",
---     queue_msg_id: 2,
---     queue_msg_delay: 0,
---     event_data: {
---         event_type: "0.(machine).creditCheck.Verifying Credentials",
---         action_type: "invoke",
---         event_payload: null
---     },
---     queue_type: "promise",
---     queue_fn_name: "verifyCredentials",
---     queue_version: "v01",
---     send_to_parent_queue_id: "44ab9fd4-4411-4e1f-aa31-c687d2b925b6",
---     send_to_parent_queue_type: "fsm",
---     send_to_parent_queue_id_event_name: "done.0.(machine).creditCheck.Verifying Credentials"
---     }
--- ]    
-
--- macro save fn
-DROP FUNCTION IF EXISTS fsm_core.archive_event_from_fsm_type_worker_v2(
-  text, bigint, jsonb, jsonb, jsonb, jsonb, jsonb, jsonb, jsonb, jsonb, jsonb, jsonb
-);
-CREATE OR REPLACE FUNCTION fsm_core.archive_event_from_fsm_type_worker_v2(
-  remove_from_current_fsm_instance_queue_id text,
-  remove_current_queue_msg_id bigint,
-  to_be_removed_schedule_queue_msg_ids jsonb,
-  to_be_removed_promise_queue_msg_ids jsonb,
-  to_be_added_schedule_queue_data jsonb,
-  to_be_added_promise_queue_data jsonb,
-  input_total_schedule_queue_data jsonb,
-  input_total_promise_queue_data jsonb,
-  fsm_instance_data_save_fsm_status jsonb,
-  fsm_instance_data_save_fsm_state jsonb,
-  fsm_instance_data_save_fsm_context jsonb,
-  fsm_instance_data_save_fsm_xstate_state jsonb,
-  send_to_parent_queue_id uuid,
-  send_to_parent_queue_type text,
-  send_to_parent_queue_id_event_name text
-) RETURNS jsonb AS $$
+CREATE OR REPLACE FUNCTION fsm_core.archive_event_from_fsm_type_worker_v2(remove_from_current_fsm_instance_queue_id text, remove_current_queue_msg_id bigint, to_be_removed_schedule_queue_msg_ids jsonb, to_be_removed_promise_queue_msg_ids jsonb, to_be_added_schedule_queue_data jsonb, to_be_added_promise_queue_data jsonb, input_total_schedule_queue_data jsonb, input_total_promise_queue_data jsonb, fsm_instance_data_save_fsm_status jsonb, fsm_instance_data_save_fsm_state jsonb, fsm_instance_data_save_fsm_context jsonb, fsm_instance_data_save_fsm_xstate_state jsonb, send_to_parent_queue_id uuid, send_to_parent_queue_type text, send_to_parent_queue_id_event_name text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
 DECLARE
     i int;
     
@@ -577,5 +409,7 @@ BEGIN
       );
 
 END;
-$$ LANGUAGE plpgsql;
+$function$
+;
+
 

--- a/packages/database-src/supabase/tests/20250219134852_archive_from_fsm_instance_worker_v2.sql
+++ b/packages/database-src/supabase/tests/20250219134852_archive_from_fsm_instance_worker_v2.sql
@@ -2,13 +2,13 @@ begin;
 select plan(12);
 
 select has_function('fsm_core', 'create_promise_queue_and_send_event_from_fsm_instance_id_v2',
-  ARRAY['text', 'jsonb', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
+  ARRAY['text', 'jsonb', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
   'create_promise_queue_and_send_event_from_fsm_instance_id_v2(...) exists');
 select has_function('fsm_core', 'create_fsm_queue_and_send_event_from_fsm_instance_id_v2',
   ARRAY['text', 'jsonb', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
   'create_fsm_queue_and_send_event_from_fsm_instance_id_v2(...) exists');
 select has_function('fsm_core', 'send_event_to_queue_from_fsm_instance_id_v2',
-  ARRAY['text', 'jsonb', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
+  ARRAY['text', 'jsonb', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
   'send_event_to_queue_from_fsm_instance_id_v2(...) exists');
 select has_function('fsm_core', 'archive_event_from_fsm_type_worker_v2',
   ARRAY['text', 'bigint', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'uuid', 'text', 'text'],
@@ -23,25 +23,25 @@ select results_eq(
   $$ select (r->>'start_queue_worker')::boolean, (r->'queue_data'->>'queueId')
      from fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(
        'evt1', '{"x": 1}'::jsonb, 'someId', 'invoke', 'someSrc', 'childOp', 'promise', 'v1',
-       'pFsm', 'v1', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) r $$,
-  $$ values (true, 'pFsm_v1_childOp'::text) $$,
-  'the first call for a not-yet-existing promise queue creates it (start_queue_worker=true)'
+       'pFsm', 'v1', 'typescript', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) r $$,
+  $$ values (true, 'pFsm_v1_p_childOp_t'::text) $$,
+  'the first call for a not-yet-existing promise queue creates it (start_queue_worker=true), naming delegated to compute_promise_queue_name_v2'
 );
 select results_eq(
   $$ select (r->>'start_queue_worker')::boolean
      from fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(
        'evt2', '{"x": 2}'::jsonb, 'someId2', 'invoke', 'someSrc', 'childOp', 'promise', 'v1',
-       'pFsm', 'v1', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) r $$,
+       'pFsm', 'v1', 'typescript', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) r $$,
   $$ values (false) $$,
   'a second call for the same promise queue reuses it (start_queue_worker=false)'
 );
 select throws_ok(
   $$ select fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2(
        'evt', '{}'::jsonb, 'id', 'invoke', 'src', 'x', 'unsupportedType', 'v1', 'p', 'v1',
-       'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) $$,
+       'typescript', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) $$,
   'P0001',
   'create_promise_queue_and_send_event_from_fsm_instance_id_v2: unsupported fsmType: unsupportedType',
-  'an unsupported fsmType raises'
+  'an unsupported fsmType still raises (validated here, before delegating naming to compute_promise_queue_name_v2)'
 );
 
 -- Characterization test: create_fsm_queue_and_send_event_from_fsm_instance_id_v2
@@ -63,7 +63,7 @@ select throws_ok(
 select throws_ok(
   $$ select fsm_core.send_event_to_queue_from_fsm_instance_id_v2(
        'evt', '{}'::jsonb, 'id', 'invoke', 'src', 'x', 'unsupportedFsmType', 'v1', 'p', 'v1',
-       'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) $$,
+       'typescript', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid) $$,
   'P0001',
   'Unsupported fsmType: unsupportedFsmType',
   'send_event_to_queue_from_fsm_instance_id_v2 rejects an unrecognized fsmType'

--- a/packages/fsm-async-worker-ts/src/asyncOperationWorkerlet/asyncOperationWorkerlet.ts
+++ b/packages/fsm-async-worker-ts/src/asyncOperationWorkerlet/asyncOperationWorkerlet.ts
@@ -7,6 +7,7 @@ import {
   asyncOperationWorkerletHeartbeat,
   asyncOperationWorkerletNotifyChannel,
   claimScheduledForAsyncOperationWorkerlet,
+  computePromiseQueueName,
   deregisterAsyncOperationWorkerlet,
   loadAsyncOperation,
   registerAsyncOperationWorkerlet,
@@ -263,18 +264,6 @@ export async function startAsyncOperationWorkerlet(
       return;
     }
 
-    // Must match the DB-side naming convention in
-    // create_promise_queue_and_send_event_from_fsm_instance_id_v2:
-    // parentFsmName || '_' || parentFsmVersion || '_' || fsmName.
-    const queueName =
-      `${entry.parent_fsm_name}_${entry.parent_fsm_version}_${entry.async_operation_name}`;
-
-    if (activeWorkers.has(queueName)) {
-      // Long-running worker already polling this queue — duplicate dispatch, skip.
-      sem.release();
-      return;
-    }
-
     const result = verified.find(
       (r) =>
         r.method === entry.async_operation_name &&
@@ -291,6 +280,24 @@ export async function startAsyncOperationWorkerlet(
           parent: entry.parent_fsm_name,
         },
       );
+      sem.release();
+      return;
+    }
+
+    // Must match the queue create_promise_queue_and_send_event_from_fsm_instance_id_v2
+    // (the fsmlet) actually writes to — both derive it from the same
+    // fsm_core.compute_promise_queue_name_v2, so they can't drift apart again.
+    const queueName = await computePromiseQueueName(deps, {
+      parentFsmName: entry.parent_fsm_name,
+      parentFsmVersion: entry.parent_fsm_version,
+      fsmType: result.fsmType,
+      fsmName: entry.async_operation_name,
+      fsmVersion: result.fsmVersion,
+      fsmLanguage: result.fsmLanguage,
+    });
+
+    if (activeWorkers.has(queueName)) {
+      // Long-running worker already polling this queue — duplicate dispatch, skip.
       sem.release();
       return;
     }

--- a/packages/fsm-core-db-ts/src/30_async_operation_worker_v2/asyncOperationWorker.ts
+++ b/packages/fsm-core-db-ts/src/30_async_operation_worker_v2/asyncOperationWorker.ts
@@ -10,6 +10,8 @@ const CLAIM_PENDING_PROMISE_EVENTS_FOR_WORKERS_FN =
   `${FSM_SCHEMA}.claim_pending_promise_events_for_workers_${FSM_SCHEMA_FN_VERSION}`;
 const ENSURE_PROMISE_QUEUE_FOR_WORKER_FN =
   `${FSM_SCHEMA}.ensure_promise_queue_for_worker_${FSM_SCHEMA_FN_VERSION}`;
+const COMPUTE_PROMISE_QUEUE_NAME_FN =
+  `${FSM_SCHEMA}.compute_promise_queue_name_${FSM_SCHEMA_FN_VERSION}`;
 
 /**
  * A registered promise-actor identity, as sent to
@@ -133,5 +135,42 @@ export async function ensurePromiseQueueForWorker(
     throw new Error("Failed to ensure promise queue for worker", {
       cause: err,
     });
+  }
+}
+
+/**
+ * Thin wrapper around `compute_promise_queue_name_v2()` -- computes the PGMQ
+ * queue name for one promise-actor identity, without creating or checking
+ * the queue (see `ensurePromiseQueueForWorker` for that). Callers that need
+ * to derive a promise-actor's queue name -- e.g. `fsm-async-worker-ts`'s
+ * `asyncOperationWorkerlet`, matching the same queue
+ * `create_promise_queue_and_send_event_from_fsm_instance_id_v2` (the fsmlet)
+ * writes to -- should call this instead of re-deriving the naming rule
+ * themselves, which is what let it drift out of sync before.
+ */
+export async function computePromiseQueueName(
+  deps: DBDeps,
+  identity: PromiseWorkerIdentity,
+): Promise<string> {
+  try {
+    const text =
+      `SELECT ${COMPUTE_PROMISE_QUEUE_NAME_FN}($1::text, $2::text, $3::text, $4::text, $5::text, $6::text) AS queue_name;`;
+    const values = [
+      identity.parentFsmName,
+      identity.parentFsmVersion,
+      identity.fsmType,
+      identity.fsmName,
+      identity.fsmVersion,
+      identity.fsmLanguage,
+    ];
+    const res = await deps.db.query<{ queue_name: string }>(text, values);
+    const queueName = res.rows?.[0]?.queue_name;
+    if (!queueName) {
+      throw new Error("compute_promise_queue_name_v2 returned no rows");
+    }
+    return queueName;
+  } catch (err) {
+    logger.error("Error in computePromiseQueueName: {error}", { error: err });
+    throw new Error("Failed to compute promise queue name", { cause: err });
   }
 }

--- a/packages/fsm-core-db-ts/src/index.ts
+++ b/packages/fsm-core-db-ts/src/index.ts
@@ -82,6 +82,7 @@ export type {
 
 export {
   claimPendingPromiseEventsForWorkers,
+  computePromiseQueueName,
   ensurePromiseQueueForWorker,
 } from "./30_async_operation_worker_v2/asyncOperationWorker.ts";
 export type {


### PR DESCRIPTION
## Summary
- `fsm_core.create_promise_queue_and_send_event_from_fsm_instance_id_v2` (the fsmlet's own promise-actor invoke path, `fsm-sync-worker-ts`) computed its own inline PGMQ queue-name formula, different from `fsm_core.compute_promise_queue_name_v2` (used by `fsm-core-async-op-worker`'s poll loop). The fsmlet is the only thing that ever writes to these queues, so the new gateway's poll loop was polling a queue name nothing wrote to — confirmed live against local Supabase (`pgmq.list_queues()` only ever showed the fsmlet's naming).
- Fix direction: keep `compute_promise_queue_name_v2` as the canonical naming (it was purpose-built with PGMQ's 48-char limit in mind); make the fsmlet's SQL delegate to it instead of its own formula. The fsmlet still validates `fsmType` itself first (raising for anything other than `promise`/`sharedPromise`), since `compute_promise_queue_name_v2` has no such validation of its own — confirmed via a pgTAP regression before fixing this back in.
- `fsm-async-worker-ts`'s `asyncOperationWorkerlet.ts` hardcoded the old formula too (documented as "must match the DB-side naming convention") — it now calls the same shared helper via a new `computePromiseQueueName()` wrapper in `fsm-core-db-ts`, so the two can't drift apart again.

## Changes
- `packages/database-src/supabase/schemas/20250219134852_archive_from_fsm_instance_worker_v2.sql`: `create_promise_queue_and_send_event_from_fsm_instance_id_v2` and its router `send_event_to_queue_from_fsm_instance_id_v2` gain an `fsmLanguage` param and delegate naming to `compute_promise_queue_name_v2`.
- `packages/database-src/supabase/tests/20250219134852_archive_from_fsm_instance_worker_v2.sql`: updated signatures/expected queue names/error messages.
- `packages/database-src/supabase/migrations/20260818095023_fsm_core--2.0.1--2.0.2.sql`: generated via `npm run supabase:restart:with:diff:withUpgradeScript:patch`.
- `packages/fsm-core-db-ts/src/30_async_operation_worker_v2/asyncOperationWorker.ts` (+ barrel export): new `computePromiseQueueName()` wrapper.
- `packages/fsm-async-worker-ts/src/asyncOperationWorkerlet/asyncOperationWorkerlet.ts`: uses the shared wrapper instead of its own hardcoded template literal.

Closes #148

## Test plan
- [x] pgTAP: `npx supabase test db` — the touched test file (`20250219134852_archive_from_fsm_instance_worker_v2.sql`) passes 12/12. Two failures elsewhere (pg_cron job-registration test, one `promise_queue_event_logs.sql` assertion) are pre-existing and in files this PR doesn't touch.
- [x] Live end-to-end: after the fix, the fsmlet creates `creditCheck_v01_p_verifyCredentials_t` (matching the gateway's naming) instead of `creditCheck_v01_verifyCredentials`.
- [x] `deno test --allow-all --no-check --env-file=.env apps/fsm-core-example/fsm/creditCheck/v01/fsm-core-xstate-fleet-journey-test.ts` against local Supabase — all 3 fleet journeys (including the `verifyCredentials` promise-actor resolution via the existing `fsm-async-worker-ts` fleet) still pass end-to-end through the renamed queue.
- Note: `--no-check` needed due to a pre-existing, unrelated type error in `packages/fsm-sync-worker-ts/src/fsmlet/fsmlet.ts` (see #146's PR for detail) — not introduced or touched by this change.