### PR TITLE
chore: publish fsm-compiler-ts CLI via dnt so npx works

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,9 +28,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # dnt: true means this package ships a CLI that must work via `npx`.
+          # `deno pack` only emits a library — it does not synthesize a
+          # package.json `bin` field, so a CLI entry point packed that way is
+          # unreachable from npx (confirmed against the Deno docs' own
+          # "Limitations" section: https://docs.deno.com/runtime/reference/cli/pack/).
+          # These packages instead build through `deno task build:npm`
+          # (packages/fsm-compiler-ts/scripts/build-npm.ts), which uses
+          # @deno/dnt to transpile + Node-shim the Deno source into `dist/`
+          # and registers both the library export and a shebanged `bin`
+          # entry in one pass. Packages without a CLI (or without a dnt
+          # build script yet) stay on `deno pack`.
           - id: compiler
             path: packages/fsm-compiler-ts
             tag_prefix: compiler-v
+            dnt: true
           - id: db
             path: packages/fsm-core-db-ts
             tag_prefix: db-v
@@ -74,14 +86,29 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Pack
-        if: steps.gate.outputs.should_run == 'true'
+      - name: Pack (library only)
+        if: steps.gate.outputs.should_run == 'true' && matrix.dnt != true
         working-directory: ${{ matrix.path }}
         run: deno pack
 
-      - name: Publish
-        if: steps.gate.outputs.should_run == 'true'
+      - name: Publish (library only)
+        if: steps.gate.outputs.should_run == 'true' && matrix.dnt != true
         working-directory: ${{ matrix.path }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish $(ls *.tgz) --access public
+
+      # dnt path (lib + npx-able CLI bin) — see the matrix comment above for why.
+      - name: Build (dnt) — lib + CLI bin
+        if: steps.gate.outputs.should_run == 'true' && matrix.dnt == true
+        working-directory: ${{ matrix.path }}
+        run: |
+          VERSION=$(node -p "require('./deno.json').version")
+          deno task build:npm "$VERSION" --copy-readme
+
+      - name: Publish (dnt dist)
+        if: steps.gate.outputs.should_run == 'true' && matrix.dnt == true
+        working-directory: ${{ matrix.path }}/dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/packages/fsm-compiler-ts/README.md
+++ b/packages/fsm-compiler-ts/README.md
@@ -31,6 +31,26 @@ deno run --allow-all --watch src/main.ts
 deno run --allow-all src/main.ts
 ```
 
+### Via npx (no Deno required)
+
+```bash
+npx @pgfsm/compiler --command <cmd> --folder <path> ...
+```
+
+This package is published to npm as `@pgfsm/compiler` with a `fsm-compiler`
+`bin` entry, so it can be run via `npx`/`npm install -g` on plain Node — no Deno
+install needed.
+
+That bin entry only exists because publishing goes through `deno task build:npm`
+(`scripts/build-npm.ts`, using `@deno/dnt`), which transpiles + Node-shims the
+source into `dist/` and registers both the library export and the shebanged CLI
+bin. `deno pack` (used for this repo's other npm-published packages) does
+**not** synthesize a `package.json` `bin` field — per the Deno docs' own
+"Limitations" section (https://docs.deno.com/runtime/reference/cli/pack/), it's
+library-publishing only. A CLI packed that way would be unreachable from `npx`,
+so `.github/workflows/npm-publish.yml` builds this package's `compiler` matrix
+entry through the dnt path instead.
+
 ## Prerequisites
 
 - **Deno** (see `.prototools` for pinned version) — always required


### PR DESCRIPTION
## Summary
- `deno pack` (used by every package in `npm-publish.yml`) does not synthesize a `package.json` `bin` field — confirmed against Deno's own docs ("Limitations": https://docs.deno.com/runtime/reference/cli/pack/) and by testing locally. A CLI packed that way is unreachable via `npx`.
- The `compiler` matrix entry in `.github/workflows/npm-publish.yml` now builds/publishes through `deno task build:npm` (dnt) instead, which registers both the library export and a shebanged `fsm-compiler` bin in `dist/`. `db`/`sync-worker`/`async-worker` are untouched — still `deno pack`.
- `packages/fsm-compiler-ts/README.md` documents the `npx @pgfsm/compiler ...` usage and the reasoning above.

## Test plan
- [x] `deno task build:npm 0.0.0-test --copy-readme` in `packages/fsm-compiler-ts` produces `dist/package.json` with a `bin.fsm-compiler` entry
- [x] `npm-publish.yml` matrix logic reviewed — `dnt: true` gate only applies to the `compiler` entry, other three packages unaffected
- [x] `deno fmt` passes (pre-commit hook)

Closes #149