### PR TITLE
chore(examples): add async-op-worker-gateway v2 fleet journey test

### DIFF
--- a/apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v2/fsm-core-xstate-fleet-journey-test.ts
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v2/fsm-core-xstate-fleet-journey-test.ts
@@ -1,0 +1,439 @@
+import { createActor, waitFor } from "xstate";
+import { diff } from "json-diff-ts";
+import { assertEquals } from "@std/assert";
+import { Pool } from "pg";
+
+import { machineWithProvider } from "../machine-with-provider.ts";
+import { runFsmScheduler, startFsmlet } from "@pgfsm/sync-worker";
+import type { FsmletHandle } from "@pgfsm/sync-worker";
+import { startActivityGatewayServer } from "@pgfsm/async-op-worker-gateway";
+import { ActorWorker } from "../../../../worker-sdk-generated/typescript/sdk.ts";
+import { ACTOR_REGISTRATIONS } from "../typescript/actors/generated-registry.ts";
+import {
+  createFsmInstanceFromName,
+  getFsmDataResolveStateValue,
+  sendEventToFsmQueueWithEventLogs,
+} from "@pgfsm/db";
+import type { DBDeps } from "@pgfsm/db";
+import { replaceUnderscoresWithSpaces } from "@pgfsm/compiler";
+
+const fsm_name = "creditCheck";
+const fsm_version = "v01";
+
+// validateSyncOperationFromFolders expects the *parent* of per-FSM folders
+// (e.g. ".../fsm", containing "creditCheck/v01").
+const FSM_FOLDER_PATH = import.meta.dirname!.split("/").slice(0, -3).join("/");
+const SKIP_DIRS = ["carVitals", "taskMachineConfig"];
+
+const SUBMIT_EVENT = {
+  type: "Submit" as const,
+  SSN: "123-45-6789",
+  firstName: "John",
+  lastName: "Doe",
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function stateHasKey(value: unknown, key: string): boolean {
+  if (typeof value !== "object" || value === null) {
+    return value === key;
+  }
+  const creditCheck = (value as Record<string, unknown>).creditCheck;
+  if (typeof creditCheck === "string") return creditCheck === key;
+  if (typeof creditCheck === "object" && creditCheck !== null) {
+    return key in (creditCheck as Record<string, unknown>);
+  }
+  return false;
+}
+
+// Poll getFsmDataResolveStateValue until the resolved (space-form) state value
+// satisfies predicate, or timeout. Returns the full data payload so callers can
+// reuse it for the context/state diff assertions without a second query.
+// deno-lint-ignore no-explicit-any
+async function pollUntilState(
+  deps: DBDeps,
+  instanceId: string,
+  predicate: (value: unknown) => boolean,
+  timeoutMs = 20000,
+  intervalMs = 300,
+  // deno-lint-ignore no-explicit-any
+): Promise<any> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const data = await getFsmDataResolveStateValue(deps, instanceId);
+    const machine = data?.resolved_state_value?.json?.machine;
+    if (machine) {
+      const value = replaceUnderscoresWithSpaces(machine);
+      if (predicate(value)) return data;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(
+    `Timeout: state predicate not satisfied for instance "${instanceId}"`,
+  );
+}
+
+function assertStateAndContextMatch(
+  // deno-lint-ignore no-explicit-any
+  data: any,
+  // deno-lint-ignore no-explicit-any
+  xstateSnapshot: any,
+) {
+  const dbStateWithSpaces = replaceUnderscoresWithSpaces(
+    data.resolved_state_value.json.machine,
+  );
+  const stateChanges = diff(dbStateWithSpaces, xstateSnapshot.value);
+
+  const dbContext = data.fsm_instance_row.fsm_instance_context;
+  const contextChanges = diff(dbContext, xstateSnapshot.context);
+
+  assertEquals(
+    stateChanges.length,
+    0,
+    `State mismatch.\nDB: ${JSON.stringify(dbStateWithSpaces)}\nXState: ${
+      JSON.stringify(xstateSnapshot.value)
+    }\nDiff: ${JSON.stringify(stateChanges, null, 2)}`,
+  );
+
+  assertEquals(
+    contextChanges.length,
+    0,
+    `Context mismatch.\nDB: ${JSON.stringify(dbContext)}\nXState: ${
+      JSON.stringify(xstateSnapshot.context)
+    }\nDiff: ${JSON.stringify(contextChanges, null, 2)}`,
+  );
+}
+
+type Fleet = {
+  pool: Pool;
+  deps: DBDeps;
+  controller: AbortController;
+  fsmletHandle: FsmletHandle;
+  worker: ActorWorker;
+  fsmSchedulerDone: Promise<void>;
+  gatewayDone: Promise<void>;
+  workerDone: Promise<void>;
+};
+
+// Boots the bounded-fleet stack (fsmscheduler + fsmlet, same as
+// test-with-async-worker-v1) plus the async-op-worker-gateway stack in place
+// of fsm-async-worker-ts: startActivityGatewayServer (sidecar + gRPC server +
+// poll loop, all sharing one SidecarGateway) and the compiler-generated
+// TypeScript worker SDK's ActorWorker, which connects to the gateway's
+// sidecar socket and registers creditCheck v01's actors. The poll loop now
+// reads from the same PGMQ queue the fsmlet writes to when invoking a
+// promise actor (see #150 -- previously these used different naming
+// schemes and the poll loop could never see a real fsmlet-driven invoke).
+// Fresh bind/sidecar socket paths per test avoid colliding with a real
+// gateway process or a previous test run's not-yet-cleaned-up socket.
+async function startFleet(): Promise<Fleet> {
+  const connectionString = Deno.env.get("DATABASE_URL")!;
+  const dbConfig = { connectionString };
+
+  const pool = new Pool({ connectionString });
+  const deps: DBDeps = { useSupabase: false, db: pool };
+  const controller = new AbortController();
+
+  const fsmSchedulerDone = runFsmScheduler(dbConfig, {
+    signal: controller.signal,
+  });
+  // Give the scheduler's LISTEN connection a moment to establish before we
+  // start creating dispatch-triggering work -- it doesn't expose a readiness
+  // signal separate from its (never-resolving-until-abort) run promise.
+  await sleep(500);
+
+  const fsmletHandle = await startFsmlet(
+    dbConfig,
+    { fsm: { folderPath: FSM_FOLDER_PATH, skipDirs: SKIP_DIRS } },
+    { signal: controller.signal, asyncOperationVerificationMode: "none" },
+  );
+
+  const runId = crypto.randomUUID();
+  const bindTarget = `unix:/tmp/pgfsm-test-gateway-${runId}.sock`;
+  const sidecarSocketPath = `/tmp/pgfsm-test-gateway-workers-${runId}.sock`;
+
+  const gatewayDone = startActivityGatewayServer({
+    bindTarget,
+    sidecarSocketPath,
+    signal: controller.signal,
+    asyncOpPollLoop: { deps, intervalMs: 1000 },
+    ensureQueueOnRegister: { deps },
+  });
+  // Give the sidecar's Unix listener a moment to bind before the worker SDK
+  // tries to connect and register.
+  await sleep(500);
+
+  const worker = new ActorWorker(
+    {
+      workerId: `test-worker-${runId}`,
+      language: "typescript",
+      gatewaySocketPath: sidecarSocketPath,
+    },
+    ACTOR_REGISTRATIONS,
+  );
+  const workerDone = worker.run();
+  // Give the worker a moment to register its actors with the gateway before
+  // the caller starts driving the FSM.
+  await sleep(500);
+
+  return {
+    pool,
+    deps,
+    controller,
+    fsmletHandle,
+    worker,
+    fsmSchedulerDone,
+    gatewayDone,
+    workerDone,
+  };
+}
+
+async function stopFleet(fleet: Fleet): Promise<void> {
+  fleet.worker.stop();
+  fleet.controller.abort();
+  await Promise.allSettled([
+    fleet.fsmSchedulerDone,
+    fleet.fsmletHandle.daemon,
+    fleet.gatewayDone,
+    fleet.workerDone,
+  ]);
+  // startFsmlet creates its own pool internally — caller owns closing it.
+  await fleet.fsmletHandle.pool?.end();
+  await fleet.pool.end();
+}
+
+// Journey 1: createActor initial context matches DB initial context after the
+// fleet (fsmscheduler + fsmlet) dispatches and runs the initial transition.
+Deno.test({
+  name: "Fleet Journey 1 (v2) — fsmscheduler + fsmlet: initial context matches",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const input_fsm_context = {
+      SSN: "123-45-6789",
+      FirstName: "John",
+      LastName: "Doe",
+      GavUnionScore: 0,
+      EquiGavinScore: 0,
+      GavperianScore: 0,
+      ErrorMessage: "",
+      MiddleScore: 0,
+      InterestRateOptions: [],
+    };
+
+    const fleet = await startFleet();
+    const actor = createActor(machineWithProvider, {
+      input: input_fsm_context,
+    });
+    actor.start();
+
+    try {
+      const xstateSnapshot = actor.getSnapshot();
+
+      const fsm_instance = await createFsmInstanceFromName(
+        fleet.deps,
+        fsm_name,
+        fsm_version,
+        input_fsm_context,
+        true,
+        // deno-lint-ignore no-explicit-any
+      ) as any;
+
+      if (!fsm_instance?.fsm_instance_id) {
+        throw new Error("Failed to create FSM instance");
+      }
+
+      const data = await pollUntilState(
+        fleet.deps,
+        fsm_instance.fsm_instance_id,
+        (value) => stateHasKey(value, "Entering Information"),
+      );
+
+      assertStateAndContextMatch(data, xstateSnapshot);
+    } finally {
+      actor.stop();
+      await stopFleet(fleet);
+    }
+  },
+});
+
+// Journey 2: Submit event — xstate actor context matches DB context after the
+// fsmlet processes the Submit event routed via fsmscheduler dispatch.
+Deno.test({
+  name:
+    "Fleet Journey 2 (v2) — Submit: xstate actor context matches DB context",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const input_fsm_context = {
+      SSN: "123-45-6789",
+      FirstName: "John",
+      LastName: "Doe",
+      GavUnionScore: 0,
+      EquiGavinScore: 0,
+      GavperianScore: 0,
+      ErrorMessage: "",
+      MiddleScore: 0,
+      InterestRateOptions: [],
+    };
+
+    const fleet = await startFleet();
+    const actor = createActor(machineWithProvider, {
+      input: input_fsm_context,
+    });
+    actor.start();
+
+    try {
+      const fsm_instance = await createFsmInstanceFromName(
+        fleet.deps,
+        fsm_name,
+        fsm_version,
+        input_fsm_context,
+        true,
+        // deno-lint-ignore no-explicit-any
+      ) as any;
+
+      if (!fsm_instance?.fsm_instance_id) {
+        throw new Error("Failed to create FSM instance");
+      }
+
+      // Wait for the initial transition to land before sending Submit.
+      await pollUntilState(
+        fleet.deps,
+        fsm_instance.fsm_instance_id,
+        (value) => stateHasKey(value, "Entering Information"),
+      );
+
+      actor.send(SUBMIT_EVENT);
+      const xstateSnapshot = actor.getSnapshot();
+
+      await sendEventToFsmQueueWithEventLogs(
+        fleet.deps,
+        fsm_instance.fsm_instance_id,
+        fsm_instance.fsm_instance_type,
+        fsm_instance.fsm_instance_version,
+        null,
+        null,
+        null,
+        "Submit",
+        "external",
+        { type: "Submit", payload: {} },
+        0,
+      );
+
+      const data = await pollUntilState(
+        fleet.deps,
+        fsm_instance.fsm_instance_id,
+        (value) => stateHasKey(value, "Verifying Credentials"),
+      );
+
+      assertStateAndContextMatch(data, xstateSnapshot);
+    } finally {
+      actor.stop();
+      await stopFleet(fleet);
+    }
+  },
+});
+
+// Journey 3: verifyCredentials resolves — async-op-worker-gateway's poll loop
+// claims the fsmlet-created promise-queue message (creditCheck_v01_p_verifyCredentials_t,
+// see #150) and dispatches it to the worker SDK's ActorWorker over the
+// sidecar socket, driving the FSM into CheckingCreditScores. Unlike v1's
+// Journey 3, no manual dispatch-trigger call is needed here — the poll loop
+// finds the message on its own once the queue exists and the worker is
+// registered.
+Deno.test({
+  name:
+    "Fleet Journey 3 (v2) — verifyCredentials done via async-op-worker-gateway: xstate actor context matches DB context in CheckingCreditScores",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const input_fsm_context = {
+      SSN: "123-45-6789",
+      FirstName: "John",
+      LastName: "Doe",
+      GavUnionScore: 0,
+      EquiGavinScore: 0,
+      GavperianScore: 0,
+      ErrorMessage: "",
+      MiddleScore: 0,
+      InterestRateOptions: [],
+    };
+
+    const fleet = await startFleet();
+    const actor = createActor(machineWithProvider, {
+      input: input_fsm_context,
+    });
+    actor.start();
+
+    try {
+      actor.send(SUBMIT_EVENT);
+      const xstateSnapshot = await waitFor(
+        actor,
+        (s) => {
+          const value = s.value as Record<string, unknown>;
+          const creditCheck = value.creditCheck;
+          return (
+            typeof creditCheck === "object" &&
+            creditCheck !== null &&
+            "CheckingCreditScores" in (creditCheck as Record<string, unknown>)
+          );
+        },
+        { timeout: 5000 },
+      );
+
+      const fsm_instance = await createFsmInstanceFromName(
+        fleet.deps,
+        fsm_name,
+        fsm_version,
+        input_fsm_context,
+        true,
+        // deno-lint-ignore no-explicit-any
+      ) as any;
+
+      if (!fsm_instance?.fsm_instance_id) {
+        throw new Error("Failed to create FSM instance");
+      }
+
+      await pollUntilState(
+        fleet.deps,
+        fsm_instance.fsm_instance_id,
+        (value) => stateHasKey(value, "Entering Information"),
+      );
+
+      await sendEventToFsmQueueWithEventLogs(
+        fleet.deps,
+        fsm_instance.fsm_instance_id,
+        fsm_instance.fsm_instance_type,
+        fsm_instance.fsm_instance_version,
+        null,
+        null,
+        null,
+        "Submit",
+        "external",
+        { type: "Submit", payload: {} },
+        0,
+      );
+
+      // Confirms the fsmlet has processed Submit and the per-actor pgmq queue
+      // (creditCheck_v01_p_verifyCredentials_t) now exists.
+      await pollUntilState(
+        fleet.deps,
+        fsm_instance.fsm_instance_id,
+        (value) => stateHasKey(value, "Verifying Credentials"),
+      );
+
+      const data = await pollUntilState(
+        fleet.deps,
+        fsm_instance.fsm_instance_id,
+        (value) => stateHasKey(value, "CheckingCreditScores"),
+        40000,
+      );
+
+      assertStateAndContextMatch(data, xstateSnapshot);
+    } finally {
+      actor.stop();
+      await stopFleet(fleet);
+    }
+  },
+});

--- a/apps/fsm-core-example/worker-sdk-generated/typescript/sdk.ts
+++ b/apps/fsm-core-example/worker-sdk-generated/typescript/sdk.ts
@@ -24,7 +24,7 @@ import {
   Http2SessionManager,
 } from "@connectrpc/connect-node";
 import * as net from "node:net";
-import { SidecarGatewayService } from "@pgfsm/proto-codegen/typescript/sidecargateway/v1/connect";
+import { SidecarGatewayService } from "@pgfsm/proto-codegen/sidecargateway/v1/connect";
 import {
   Heartbeat,
   type Invoke,
@@ -35,7 +35,7 @@ import {
   SessionRequest,
   type SessionResponse,
   Unregister,
-} from "@pgfsm/proto-codegen/typescript/sidecargateway/v1/pb";
+} from "@pgfsm/proto-codegen/sidecargateway/v1/pb";
 
 const logger = getLogger([
   "@pgfsm/worker",

--- a/packages/fsm-compiler-ts/src/operation-logic-scaffold.ts
+++ b/packages/fsm-compiler-ts/src/operation-logic-scaffold.ts
@@ -817,9 +817,9 @@ export async function writeAggregateGoRegistry(
  * bookkeeping moot.
  */
 const GATEWAY_SIDECAR_PROTO_CONNECT_IMPORT_PATH =
-  "@pgfsm/proto-codegen/typescript/sidecargateway/v1/connect";
+  "@pgfsm/proto-codegen/sidecargateway/v1/connect";
 const GATEWAY_SIDECAR_PROTO_PB_IMPORT_PATH =
-  "@pgfsm/proto-codegen/typescript/sidecargateway/v1/pb";
+  "@pgfsm/proto-codegen/sidecargateway/v1/pb";
 /**
  * pip `-e` (editable install) target from
  * `<appRoot>/worker-sdk-generated/python/` (where `requirements.txt` lives)

--- a/packages/fsm-compiler-ts/test/operation-logic-scaffold.test.ts
+++ b/packages/fsm-compiler-ts/test/operation-logic-scaffold.test.ts
@@ -878,13 +878,13 @@ Deno.test("writeWorkerSdk - writes cli/main+sdk+protocol+manifest per language, 
     const tsSdk = await Deno.readTextFile(`${base}/typescript/sdk.ts`);
     assertEquals(
       tsSdk.includes(
-        'from "@pgfsm/proto-codegen/typescript/sidecargateway/v1/connect";',
+        'from "@pgfsm/proto-codegen/sidecargateway/v1/connect";',
       ),
       true,
     );
     assertEquals(
       tsSdk.includes(
-        'from "@pgfsm/proto-codegen/typescript/sidecargateway/v1/pb";',
+        'from "@pgfsm/proto-codegen/sidecargateway/v1/pb";',
       ),
       true,
     );

--- a/packages/fsm-core-async-op-worker/GOAL.md
+++ b/packages/fsm-core-async-op-worker/GOAL.md
@@ -144,13 +144,18 @@ helpers, callable from anywhere):
 
 ### Real remaining gaps (not part of the original 8 steps)
 
-- **No outcome-dependent `eventName` prefixing.**
-  `claim_pending_promise_events_for_workers_v2` runs before `sidecar.invoke()`,
-  so it can't know success/failure yet — `eventName` in the claimed row is
-  always the raw `sendToParentQueueIdEventName` from the PGMQ message, never
-  `"xstate.done.actor."`/`"xstate.error.actor."`-prefixed. Whether/how to
-  compute that prefix is a `dispatchAndArchive()` (TS-side) concern, not yet
-  implemented.
+- ~~No outcome-dependent `eventName` prefixing.~~ **Fixed.**
+  `claim_pending_promise_events_for_workers_v2` still runs before
+  `sidecar.invoke()`, so `eventName` in the claimed row is still the raw
+  `sendToParentQueueIdEventName` from the PGMQ message — but
+  `dispatchAndArchive()` now prefixes it with `"xstate.done.actor."` /
+  `"xstate.error.actor."` (based on the invoke outcome) before archiving,
+  matching `fsm-async-worker-ts`'s working convention
+  (`fsmpromiseworker-helper.ts`'s `send_event_name_to_parent_queue_id`). Without
+  this the fsmlet could never find a matching transition for the raw eventName
+  and the FSM instance stayed stuck at the invoking state forever, even though
+  the actor invoke itself succeeded — caught via a real end-to-end run, not just
+  unit coverage.
 - **PGMQ's 48-character queue name limit** isn't fully solved. The
   `fsm_type = "promise"` shortening (drop `fsm_version`, first-char
   `fsm_language`) fits typical identities, but the non-`"promise"` path

--- a/packages/fsm-core-async-op-worker/src/asyncOpPollLoop.ts
+++ b/packages/fsm-core-async-op-worker/src/asyncOpPollLoop.ts
@@ -161,11 +161,24 @@ export async function dispatchAndArchive(
 
   const executionFinishedAt = new Date();
 
+  // Outcome-dependent prefix, matching fsm-async-worker-ts's working
+  // convention exactly (fsmpromiseworker-helper.ts's
+  // send_event_name_to_parent_queue_id): the fsmlet only recognizes
+  // "xstate.done.actor.<base>" / "xstate.error.actor.<base>" as a valid
+  // transition event -- the claimed row's raw eventName (the un-prefixed
+  // state-node id the fsmlet itself sent, e.g.
+  // "0.(machine).creditCheck.Verifying Credentials") never matches any
+  // transition on its own, which used to leave the FSM stuck at that state
+  // forever even though the actor invoke above succeeded.
+  const prefixedEventName = `${
+    eventStatus === "succeeded" ? "xstate.done.actor." : "xstate.error.actor."
+  }${event.eventName}`;
+
   logger.info(
     "Dispatch result for actor {actorKey}, event {eventName}: status={status}, output={output}, error={error}",
     {
       actorKey: actorKeyOf(event),
-      eventName: event.eventName,
+      eventName: prefixedEventName,
       status: eventStatus,
       output: eventOutput,
       error: errorMessage,
@@ -178,7 +191,7 @@ export async function dispatchAndArchive(
       event.promiseQueueType,
       event.promiseQueueVersion,
       event.msgId,
-      event.eventName,
+      prefixedEventName,
       event.eventActionType,
       eventOutput,
       event.eventDelay,

--- a/packages/fsm-core-async-op-worker/src/gatewayClient.ts
+++ b/packages/fsm-core-async-op-worker/src/gatewayClient.ts
@@ -25,7 +25,7 @@ import {
 } from "@connectrpc/connect-node";
 import * as net from "node:net";
 import type { ClientSessionOptions } from "node:http2";
-import { ActivityGatewayService } from "@pgfsm/proto-codegen/typescript/activitygateway/v1/connect";
+import { ActivityGatewayService } from "@pgfsm/proto-codegen/activitygateway/v1/connect";
 
 // Connect's `Client<typeof ActivityGatewayService>` utility type resolves every
 // method to `never` under `deno check` specifically (reproduced in complete

--- a/packages/fsm-core-async-op-worker/src/gatewayServer.ts
+++ b/packages/fsm-core-async-op-worker/src/gatewayServer.ts
@@ -34,7 +34,7 @@ import {
   type RegisteredActor,
   SidecarGateway,
 } from "./sidecar/gateway.ts";
-import { ActivityGatewayService } from "@pgfsm/proto-codegen/typescript/activitygateway/v1/connect";
+import { ActivityGatewayService } from "@pgfsm/proto-codegen/activitygateway/v1/connect";
 import { startAsyncOpPollLoop } from "./asyncOpPollLoop.ts";
 
 const logger = getLogger(["@pgfsm/worker", "async-op-worker-gateway"]);

--- a/packages/fsm-core-async-op-worker/src/sidecar/gateway.ts
+++ b/packages/fsm-core-async-op-worker/src/sidecar/gateway.ts
@@ -31,14 +31,14 @@ import {
   type ServiceImpl,
 } from "@connectrpc/connect";
 import * as http2 from "node:http2";
-import { SidecarGatewayService } from "@pgfsm/proto-codegen/typescript/sidecargateway/v1/connect";
+import { SidecarGatewayService } from "@pgfsm/proto-codegen/sidecargateway/v1/connect";
 import {
   Invoke,
   type Register,
   RegisterAck,
   type SessionRequest,
   SessionResponse,
-} from "@pgfsm/proto-codegen/typescript/sidecargateway/v1/pb";
+} from "@pgfsm/proto-codegen/sidecargateway/v1/pb";
 
 const logger = getLogger([
   "@pgfsm/worker",


### PR DESCRIPTION
## Summary
- Adds `test-with-async-worker-v2/fsm-core-xstate-fleet-journey-test.ts`, parallel to `test-with-async-worker-v1/` (#146/#147) but using `@pgfsm/async-op-worker-gateway` (`packages/fsm-core-async-op-worker`) + the compiler-generated TypeScript worker SDK instead of `@pgfsm/async-worker` (`fsm-async-worker-ts`). Journeys 1 & 2 are the same fsmScheduler+fsmlet stack as v1 (no promise actors involved). Journey 3 starts `startActivityGatewayServer` (gateway + sidecar + poll loop) and the generated `ActorWorker` instead of the legacy scheduler/workerlet pair, and drops the manual dispatch-trigger call now that the poll loop finds the fsmlet-created queue on its own (#150).
- Two more pre-existing bugs surfaced and fixed getting this to actually pass end-to-end against local Supabase (both confirmed via a live debug run with LogTape logging enabled + direct pgmq inspection, not just guessed):
  - **Wrong import paths**: `@pgfsm/proto-codegen/typescript/...` doesn't match the package's real export map (`packages/fsm-proto-codegen/gen/typescript/deno.json` has no `typescript/` prefix). Broke `fsm-core-async-op-worker`'s `gatewayClient.ts`/`gatewayServer.ts`/`sidecar/gateway.ts`, the compiler's worker-sdk scaffold constant (`operation-logic-scaffold.ts`, used to generate every language's `sdk.ts`) + its test, and the already-generated `apps/fsm-core-example/worker-sdk-generated/typescript/sdk.ts`. Fixed to `@pgfsm/proto-codegen/...` everywhere.
  - **Missing outcome-dependent `eventName` prefix**: `dispatchAndArchive()` (`asyncOpPollLoop.ts`) archived the claimed row's raw `eventName` instead of prefixing it `xstate.done.actor.`/`xstate.error.actor.` per outcome, matching `fsm-async-worker-ts`'s working convention (`fsmpromiseworker-helper.ts`'s `send_event_name_to_parent_queue_id`). Without the prefix the fsmlet's macrostep function logs `No transitions found for the given FSM name and version` and the FSM instance stays stuck at the invoking state forever — even though the actor invoke itself succeeded. This was already flagged as a known, unimplemented gap in `GOAL.md`; now implemented and that doc updated.

Closes #152

## Test plan
- [x] `deno test --allow-all --no-check --env-file=.env apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v2/fsm-core-xstate-fleet-journey-test.ts` against local Supabase — 3 passed, 0 failed.
- [x] Re-ran `test-with-async-worker-v1`'s equivalent test (unaffected by this change) — still 3 passed, 0 failed.
- [x] `deno test --allow-all --no-check packages/fsm-compiler-ts/test/operation-logic-scaffold.test.ts` — 43 passed, 0 failed (covers the corrected import-path constant).
- Note: `--no-check` needed due to a pre-existing, unrelated type error in `packages/fsm-sync-worker-ts/src/fsmlet/fsmlet.ts` (see #146's PR) and a separate pre-existing implicit-`any` error in `fsm-core-db-ts/src/30_async_operation_worker_v2/asyncOperationWorker.ts:63` — neither introduced or touched by this change.