### PR TITLE
chore(tooling): pass --no-check to VS Code Debug Test codelens

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,8 @@
     "--allow-all",
     "--unstable-detect-cjs",
     "--unstable-sloppy-imports",
-    "--env-file=${workspaceFolder}/.env"
+    "--env-file=${workspaceFolder}/.env",
+    "--no-check"
   ],
 
   "deno.suggest.imports.autoDiscover": true,


### PR DESCRIPTION
## Summary
- `deno.codeLens.testArgs` in `.vscode/settings.json` was missing `--no-check`, unlike `launch.json`'s debug config
- This made the Deno extension's "Run Test" / "Debug Test" codelens fail on unrelated, pre-existing type errors elsewhere in the workspace instead of launching the debugger for the file under test
- Editor-only change — CI and `deno task test` still type-check normally

Closes #162

## Test plan
- [x] Opened `apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v1/fsm-core-xstate-fleet-journey-test.ts` and confirmed the codelens task now runs with `--no-check` and reaches the debugger instead of failing on the unrelated `fsmlet.ts` type error