### PR TITLE
chore(ci): publish prerelease versions under their npm dist-tag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -86,6 +86,23 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      # A prerelease version (e.g. 0.1.0-alpha.0) must publish under its own
+      # dist-tag — `npm publish` with no --tag defaults to `latest` no matter
+      # what the version string says, so without this an alpha would silently
+      # become the default `npm install` resolution.
+      - name: Determine npm dist-tag
+        id: dist-tag
+        if: steps.gate.outputs.should_run == 'true'
+        working-directory: ${{ matrix.path }}
+        run: |
+          VERSION=$(node -p "require('./deno.json').version")
+          if [[ "$VERSION" =~ -([a-zA-Z]+)(\.|$) ]]; then
+            TAG="${BASH_REMATCH[1]}"
+          else
+            TAG="latest"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Pack (library only)
         if: steps.gate.outputs.should_run == 'true' && matrix.dnt != true
         working-directory: ${{ matrix.path }}
@@ -96,7 +113,7 @@ jobs:
         working-directory: ${{ matrix.path }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish $(ls *.tgz) --access public
+        run: npm publish $(ls *.tgz) --access public --tag "${{ steps.dist-tag.outputs.tag }}"
 
       # dnt path (lib + npx-able CLI bin) — see the matrix comment above for why.
       - name: Build (dnt) — lib + CLI bin
@@ -111,4 +128,4 @@ jobs:
         working-directory: ${{ matrix.path }}/dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access public --tag "${{ steps.dist-tag.outputs.tag }}"

--- a/packages/fsm-compiler-ts/deno.json
+++ b/packages/fsm-compiler-ts/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@pgfsm/compiler",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## Summary
- `npm publish` always defaults to the `latest` dist-tag regardless of the version string, so a prerelease like `0.1.0-alpha.0` would have silently become the default `npm install` resolution.
- Added a "Determine npm dist-tag" step that reads the version from `deno.json`, extracts a semver prerelease identifier (`alpha`, `beta`, `rc`, ...), and passes it as `--tag` to both `npm publish` invocations (plain versions still publish to `latest`).
- Bumped `@pgfsm/compiler` to `0.1.0-alpha.0` for its first, alpha-only release (installable via `@pgfsm/compiler@alpha`).

## Test plan
- [x] `deno fmt` / pre-commit hooks pass
- [x] Verified the bash prerelease-detection regex against `0.1.0`, `0.1.0-alpha.0`, `1.2.3-beta.5`, `1.0.0-rc.1` — resolves to `latest`, `alpha`, `beta`, `rc` respectively
- [ ] Actual `npm publish --tag alpha` run (requires CI secrets / npm org access — not exercised locally)

Closes #164