### PR TITLE
chore(compiler-ts): fix @pgfsm/compiler npm license to Apache-2.0

### DIFF
--- a/packages/fsm-compiler-ts/deno.json
+++ b/packages/fsm-compiler-ts/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@pgfsm/compiler",
-  "version": "0.1.0-alpha.0",
-  "license": "MIT",
+  "version": "0.1.0-alpha.1",
+  "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/fsm-compiler-ts/scripts/build-npm.ts
+++ b/packages/fsm-compiler-ts/scripts/build-npm.ts
@@ -19,7 +19,7 @@ await build({
     name: "@pgfsm/compiler",
     version: Deno.args[0]?.replace(/^v/, "") ?? "0.0.0",
     description: "FSM JSON compiler for PostgreSQL-backed state machines",
-    license: "MIT",
+    license: "Apache-2.0",
     // pg ships no types of its own; dnt only auto-installs packages that
     // are themselves import specifiers, so without this the type-check
     // pass can't resolve `import ... from "pg"` (deno.json's own


### PR DESCRIPTION
## Summary
- `@pgfsm/compiler` was publishing with `license: MIT` in both `deno.json` and the dnt `build-npm.ts` script, mismatching the repo's actual Apache-2.0 license (root `LICENSE`, `REUSE.toml`, and the package's own `LICENSE` file are all Apache-2.0).
- Fixed both to `Apache-2.0`.
- Bumped version to `0.1.0-alpha.1` since `0.1.0-alpha.0` is already published on npm (with the wrong metadata) and npm doesn't allow republishing under the same version string.

## Test plan
- [x] Grepped `packages/fsm-compiler-ts` for stray "MIT" references — none left
- [x] `deno fmt` / pre-commit hooks pass
- [ ] Actual publish of 0.1.0-alpha.1 (tag push or workflow_dispatch) — not run as part of this change

Closes #166