### PR TITLE
chore(sync-worker): ship CLI via dnt, fix npm license mismatch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,6 +49,7 @@ jobs:
           - id: sync-worker
             path: packages/fsm-sync-worker-ts
             tag_prefix: sync-worker-v
+            dnt: true
           - id: async-worker
             path: packages/fsm-async-worker-ts
             tag_prefix: async-worker-v

--- a/packages/fsm-sync-worker-ts/README.md
+++ b/packages/fsm-sync-worker-ts/README.md
@@ -1,0 +1,76 @@
+# fsm-sync-worker-ts — Worker Fleet
+
+The out-of-band worker fleet that drives FSM instances forward (the HTTP API
+never blocks on or owns worker lifecycle). Runs on Deno.
+
+## What it does
+
+Kubernetes-style split:
+
+| CLI              | Role                                                                            |
+| ---------------- | ------------------------------------------------------------------------------- |
+| **fsmlet**       | Long-running node agent (kubelet equivalent) — claims and drives FSM workers    |
+| **fsmscheduler** | Control-plane routing process (kube-scheduler equivalent), run once per cluster |
+| **fsmctl**       | One-shot control CLI (kubectl equivalent) — create/resume/send/stop             |
+| **pgcron**       | One-shot deploy-time script — (re)registers the `pg_cron` drain job             |
+
+Full flag reference, examples, and the dispatch model behind these four CLIs
+live in [`docs/guides/CLI-USAGE.md`](./docs/guides/CLI-USAGE.md).
+
+## How to run
+
+```bash
+# From this package's directory
+deno task fsmlet -f <fsm-folder-path>
+deno task fsmscheduler
+deno task cli -c create -n <fsm-name> -v <fsm-version>
+deno task pgcron
+```
+
+### Via npx (no Deno required)
+
+```bash
+npx @pgfsm/sync-worker fsmlet -f <fsm-folder-path>
+npx @pgfsm/sync-worker fsmscheduler
+npx @pgfsm/sync-worker fsmctl -c create -n <fsm-name> -v <fsm-version>
+npx @pgfsm/sync-worker pgcron
+```
+
+This package is published to npm as `@pgfsm/sync-worker` with `fsmlet`,
+`fsmscheduler`, `fsmctl`, and `pgcron` `bin` entries, so each can be run via
+`npx`/`npm install -g` on plain Node — no Deno install needed.
+
+Those bin entries only exist because publishing goes through
+`deno task build:npm` (`scripts/build-npm.ts`, using `@deno/dnt`), which
+transpiles + Node-shims the source into `dist/` and registers the library export
+alongside the shebanged CLI bins in one pass. `deno pack` (used for this repo's
+other npm-published packages) does **not** synthesize a `package.json` `bin`
+field, so a CLI packed that way would be unreachable from `npx` —
+`.github/workflows/npm-publish.yml` builds this package's `sync-worker` matrix
+entry through the dnt path instead.
+
+## Prerequisites
+
+- **Deno** (see `.prototools` for pinned version) — always required to run from
+  source
+- **Database connection** — `DATABASE_URL` in `.env`, or `--db-url`/`-d` passed
+  to any CLI
+
+## Key exports
+
+```typescript
+import {
+  runFsmlet, // node-agent implementation behind the fsmlet CLI
+  runFsmScheduler, // control-plane routing implementation behind fsmscheduler
+  startFSMWorker, // drive a single FSM instance
+  startFSMWorkerWithDBLock, // same, holding a DB-level advisory lock
+} from "@pgfsm/sync-worker";
+```
+
+## Deno version
+
+Managed by `.prototools`. Install with:
+
+```bash
+proto install deno --pin local
+```

--- a/packages/fsm-sync-worker-ts/deno.json
+++ b/packages/fsm-sync-worker-ts/deno.json
@@ -1,16 +1,17 @@
 {
   "name": "@pgfsm/sync-worker",
   "version": "0.1.0",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts"
   },
   "imports": {
+    "@deno/dnt": "jsr:@deno/dnt@^0.43.0",
     "@logtape/logtape": "jsr:@logtape/logtape@^2.2",
     "@std/cli": "jsr:@std/cli@1",
-    "@types/pg": "npm:@types/pg@^8.15.2",
+    "@types/pg": "npm:@types/pg@^8.18.0",
     "dotenv": "npm:dotenv@^16.5.0",
-    "pg": "npm:pg@^8.16.0",
+    "pg": "npm:pg@^8.20.0",
     "xstate": "npm:xstate@^5.26.0"
   },
   "tasks": {
@@ -19,6 +20,7 @@
     "fsmlet": "deno run --allow-all src/cli/fsmlet.ts",
     "fsmscheduler": "deno run --allow-all src/cli/fsmscheduler.ts",
     "pgcron": "deno run --allow-all src/cli/pgcron.ts",
+    "build:npm": "deno run --allow-all scripts/build-npm.ts",
     "check": "deno check src/index.ts"
   }
 }

--- a/packages/fsm-sync-worker-ts/deno.json
+++ b/packages/fsm-sync-worker-ts/deno.json
@@ -7,12 +7,11 @@
   },
   "imports": {
     "@deno/dnt": "jsr:@deno/dnt@^0.43.0",
-    "@logtape/logtape": "jsr:@logtape/logtape@^2.2",
+    "@logtape/logtape": "npm:@logtape/logtape@^2.2",
     "@std/cli": "jsr:@std/cli@1",
     "@types/pg": "npm:@types/pg@^8.18.0",
     "dotenv": "npm:dotenv@^16.5.0",
-    "pg": "npm:pg@^8.20.0",
-    "xstate": "npm:xstate@^5.26.0"
+    "pg": "npm:pg@^8.20.0"
   },
   "tasks": {
     "cli": "deno run --allow-all src/cli/fsmctl.ts",

--- a/packages/fsm-sync-worker-ts/scripts/build-npm.ts
+++ b/packages/fsm-sync-worker-ts/scripts/build-npm.ts
@@ -1,0 +1,40 @@
+import { build, emptyDir } from "@deno/dnt";
+
+await emptyDir("./dist");
+
+await build({
+  entryPoints: [
+    "./src/index.ts",
+    { kind: "bin", name: "fsmlet", path: "./src/cli/fsmlet.ts" },
+    { kind: "bin", name: "fsmscheduler", path: "./src/cli/fsmscheduler.ts" },
+    { kind: "bin", name: "fsmctl", path: "./src/cli/fsmctl.ts" },
+    { kind: "bin", name: "pgcron", path: "./src/cli/pgcron.ts" },
+  ],
+  outDir: "./dist",
+  shims: {
+    deno: true,
+  },
+  package: {
+    name: "@pgfsm/sync-worker",
+    version: Deno.args[0]?.replace(/^v/, "") ?? "0.0.0",
+    description:
+      "Out-of-band worker fleet (fsmlet/fsmscheduler/fsmctl/pgcron) driving FSM instances for PostgreSQL-backed state machines",
+    license: "Apache-2.0",
+    // pg ships no types of its own; dnt only auto-installs packages that
+    // are themselves import specifiers, so without this the type-check
+    // pass can't resolve `import ... from "pg"` (deno.json's own
+    // "@types/pg" import mapping isn't picked up the same way here).
+    devDependencies: {
+      "@types/pg": "^8.18.0",
+    },
+  },
+  compilerOptions: {
+    lib: ["ES2022", "DOM"],
+    target: "ES2022",
+  },
+  postBuild() {
+    if (Deno.args.includes("--copy-readme")) {
+      Deno.copyFileSync("README.md", "dist/README.md");
+    }
+  },
+});


### PR DESCRIPTION
## Summary
- Flip the `sync-worker` matrix entry in `.github/workflows/npm-publish.yml` to the `dnt` publish path (`dnt: true`, matching `@pgfsm/compiler`), so `@pgfsm/sync-worker` ships both the library export and `fsmlet`/`fsmscheduler`/`fsmctl`/`pgcron` `bin` entries via `npx` — previously it published library-only through `deno pack`, which can't synthesize a `bin` field.
- Add `packages/fsm-sync-worker-ts/scripts/build-npm.ts` (the dnt build script) and a `build:npm` deno task, modeled on the compiler package's.
- Add `packages/fsm-sync-worker-ts/README.md` (needed for the `--copy-readme` step the publish workflow already runs for dnt packages).
- Fix `packages/fsm-sync-worker-ts/deno.json`: `license` was `"MIT"`, but the package's own `LICENSE` file (and the repo root) is Apache-2.0.
- Align `pg`/`@types/pg` pins with `@pgfsm/db`'s (`^8.20.0`/`^8.18.0`) — `sync-worker` re-exports from `@pgfsm/db`, and dnt's bundled type-check requires matching npm specifier versions across the whole entry-point graph; the old `^8.16.0`/`^8.15.2` pins caused a hard `dnt` build failure.

## Known follow-up (not in scope here)
`deno task build:npm` currently fails at the type-check step on a **pre-existing, unrelated** bug: `fsmlet.ts` passes `ActorReference[]` (from `@pgfsm/compiler`, `fsmVersion?: string`) into functions expecting `AsyncActor[]` (from `@pgfsm/db`, `fsmVersion: string` required). Confirmed this also fails identically on unmodified `main` via `deno task check` — CI just never ran that check for this package. Filed as #169 and assigned to me; the `npm-publish` CI job for `sync-worker` won't go green until it lands.

Closes #167

## Test plan
- [x] `deno task check` in `fsm-sync-worker-ts` — confirmed the 3 failures are pre-existing on `main`, unrelated to this change
- [x] `deno task build:npm 0.1.0 --copy-readme` — ran to validate the script wiring; fails at type-check on the #169 bug (expected, tracked separately)
- [x] `deno fmt` — clean
- [ ] Full green `npm-publish` CI run for `sync-worker` — blocked on #169