### PR TITLE
chore(async-worker): rename v1 to @pgfsm/async-worker-old, v2 to @pgfsm/async-worker

### DIFF
--- a/apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v1/fsm-core-xstate-fleet-journey-test.ts
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v1/fsm-core-xstate-fleet-journey-test.ts
@@ -9,8 +9,8 @@ import type { FsmletHandle } from "@pgfsm/sync-worker";
 import {
   runAsyncOperationScheduler,
   startAsyncOperationWorkerlet,
-} from "@pgfsm/async-worker";
-import type { AsyncOperationWorkerletHandle } from "@pgfsm/async-worker";
+} from "@pgfsm/async-worker-old";
+import type { AsyncOperationWorkerletHandle } from "@pgfsm/async-worker-old";
 import {
   createAsyncOperationInstanceAndNotifyAsyncOperationSchedulerWork,
   createFsmInstanceFromName,

--- a/apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v2/fsm-core-xstate-fleet-journey-test.ts
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/test-with-async-worker-v2/fsm-core-xstate-fleet-journey-test.ts
@@ -6,7 +6,7 @@ import { Pool } from "pg";
 import { machineWithProvider } from "../machine-with-provider.ts";
 import { runFsmScheduler, startFsmlet } from "@pgfsm/sync-worker";
 import type { FsmletHandle } from "@pgfsm/sync-worker";
-import { startActivityGatewayServer } from "@pgfsm/async-op-worker-gateway";
+import { startActivityGatewayServer } from "@pgfsm/async-worker";
 import { ActorWorker } from "../../../../worker-sdk-generated/typescript/sdk.ts";
 import { ACTOR_REGISTRATIONS } from "../typescript/actors/generated-registry.ts";
 import {

--- a/packages/fsm-async-worker-ts/CLAUDE.md
+++ b/packages/fsm-async-worker-ts/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Async-Operation Worker Fleet (`packages/fsm-async-worker-ts/`)
 
-Scoped guidance for `@pgfsm/async-worker`. Repo-wide conventions and session
+Scoped guidance for `@pgfsm/async-worker-old`. Repo-wide conventions and session
 protocol live in the root `CLAUDE.md` / `AGENTS.md`.
 
 ## What it is

--- a/packages/fsm-async-worker-ts/deno.json
+++ b/packages/fsm-async-worker-ts/deno.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pgfsm/async-worker",
+  "name": "@pgfsm/async-worker-old",
   "version": "0.1.0",
   "license": "MIT",
   "exports": {

--- a/packages/fsm-core-async-op-worker/deno.json
+++ b/packages/fsm-core-async-op-worker/deno.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pgfsm/async-op-worker-gateway",
+  "name": "@pgfsm/async-worker",
   "version": "0.1.0",
   "license": "MIT",
   "exports": {

--- a/packages/fsm-core-async-op-worker/docs/guides/CLI-USAGE.md
+++ b/packages/fsm-core-async-op-worker/docs/guides/CLI-USAGE.md
@@ -2,10 +2,10 @@
 
 ## Core objective
 
-`fsm-core-async-op-worker` (`@pgfsm/async-op-worker-gateway`) is a **standalone
-alternative to `fsm-async-worker-ts`** for promise-type async FSM operations
-across polyglot (TypeScript/Python/Rust/Go) actors — not a passive service
-another orchestrator's poll/claim/archive loop calls into.
+`fsm-core-async-op-worker` (`@pgfsm/async-worker`) is a **standalone alternative
+to `fsm-async-worker-ts`** for promise-type async FSM operations across polyglot
+(TypeScript/Python/Rust/Go) actors — not a passive service another
+orchestrator's poll/claim/archive loop calls into.
 
 Concretely, it:
 

--- a/packages/fsm-core-db-ts/src/30_async_operation_worker_v2/asyncOperationWorker.ts
+++ b/packages/fsm-core-db-ts/src/30_async_operation_worker_v2/asyncOperationWorker.ts
@@ -16,7 +16,7 @@ const COMPUTE_PROMISE_QUEUE_NAME_FN =
 /**
  * A registered promise-actor identity, as sent to
  * `claimPendingPromiseEventsForWorkers` — mirrors
- * `@pgfsm/async-op-worker-gateway`'s `SidecarGateway`-registered actor shape
+ * `@pgfsm/async-worker`'s `SidecarGateway`-registered actor shape
  * minus `handler` (an in-process function reference, not serializable to
  * Postgres).
  */


### PR DESCRIPTION
## Summary
- \`packages/fsm-core-async-op-worker/deno.json\`: \`name\` changed from \`@pgfsm/async-op-worker-gateway\` to \`@pgfsm/async-worker\` — short, matches sibling package naming (\`@pgfsm/compiler\`, \`@pgfsm/db\`, \`@pgfsm/sync-worker\`, \`@pgfsm/logging\`), drops the internal "gateway" implementation detail from the public identity.
- \`packages/fsm-async-worker-ts/deno.json\`: \`name\` changed from \`@pgfsm/async-worker\` to \`@pgfsm/async-worker-old\`, freeing the name for v2. v1 is otherwise untouched — still a functioning workspace member, still exercised by \`test-with-async-worker-v1\`.
- Updated import specifiers in both example fleet-journey tests (\`test-with-async-worker-v1\`, \`test-with-async-worker-v2\`) and doc references in both packages' \`CLAUDE.md\`/\`CLI-USAGE.md\` to match.

## Why not just delete v1 and take the exact name?
\`@pgfsm/async-worker\`'s only remaining consumer after #172 was \`test-with-async-worker-v1\` — a real, currently-passing end-to-end regression test exercising the full v1 worker fleet (\`startAsyncOperationWorkerlet\`, \`runAsyncOperationScheduler\`), not dead code. Deno workspaces also reject two members declaring the same \`name\` (confirmed via \`deno check\`, hard error), so v1 needed *some* different name regardless. Renaming it to \`@pgfsm/async-worker-old\` keeps that coverage intact while giving v2 the clean name.

Closes #171

## Test plan
- [x] \`deno check packages/fsm-core-async-op-worker/src/index.ts\` — clean, no workspace name collision
- [x] \`deno task check\` in \`fsm-async-worker-ts\` — clean
- [x] \`deno check\` on both \`test-with-async-worker-v1\` and \`test-with-async-worker-v2\` fleet-journey tests — only the 3 pre-existing, unrelated errors tracked in #169
- [x] Grepped for every remaining \`@pgfsm/async-worker\`/\`@pgfsm/async-op-worker-gateway\` reference repo-wide to confirm each now points at the correct package
- [x] \`deno fmt\` — clean