### PR TITLE
chore(async-op-worker): ship CLI via dnt, fix license, prefer npm specifiers

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,8 +51,9 @@ jobs:
             tag_prefix: sync-worker-v
             dnt: true
           - id: async-worker
-            path: packages/fsm-async-worker-ts
+            path: packages/fsm-core-async-op-worker
             tag_prefix: async-worker-v
+            dnt: true
 
     steps:
       - name: Gate — decide if this package should publish

--- a/packages/fsm-core-async-op-worker/LICENSE
+++ b/packages/fsm-core-async-op-worker/LICENSE
@@ -1,0 +1,185 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and its derivative works thereof.
+
+      "Contribution" shall mean, as used in this License, any work of
+      authorship, including the original version of the Work and any
+      modifications or additions to that Work or Derivative Works of the
+      Work, that is intentionally submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and subsequently
+      incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or a Contribution
+      incorporated within the Work constitutes direct or contributory patent
+      infringement, then any patent licenses granted to You under this License
+      for that Work shall terminate as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the Work
+      or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You meet
+      the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative Works
+          a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works that
+          You distribute, all copyright, patent, trademark, and attribution
+          notices from the Source form of the Work, excluding those notices
+          that do not pertain to any part of the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the attribution
+          notices contained within such NOTICE file, in at least one of the
+          following places: within a NOTICE text file distributed as part of
+          the Derivative Works; within the Source form or documentation, if
+          provided along with the Derivative Works; or, within a display
+          generated by the Derivative Works, if and wherever such third-party
+          notices normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License. You may
+          add Your own attribution notices within Derivative Works that You
+          distribute, alongside or as an addendum to the NOTICE text from the
+          Work, provided that such additional attribution notices cannot be
+          construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and may
+      provide additional grant of rights to use, reproduce, modify, and
+      distribute Your modifications, or for such Derivative Works as a whole,
+      under terms and conditions of Your choice, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with the
+      conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any conditions of title,
+      non-infringement, merchantability, or fitness for a particular purpose.
+      You are solely responsible for determining the appropriateness of using
+      or redistributing the Work and assume any risks associated with Your
+      exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a result
+      of this License or out of the use or inability to use the Work
+      (including but not limited to damages for loss of goodwill, work
+      stoppage, computer failure or malfunction, or all other commercial
+      damages or losses), even if such Contributor has been advised of the
+      possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing the
+      Work or Derivative Works thereof, You may choose to offer, and charge
+      a fee for, acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may offer such obligations
+      only on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by, or
+      claims asserted against, such Contributor by reason of your accepting
+      any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Niraj Kashyap
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/fsm-core-async-op-worker/README.md
+++ b/packages/fsm-core-async-op-worker/README.md
@@ -1,0 +1,81 @@
+# fsm-core-async-op-worker — Activity Gateway
+
+The Activity Gateway for promise-type async FSM operations across polyglot
+(TypeScript/Python/Rust/Go) actors — a standalone alternative to
+`fsm-async-worker-ts` (v1), not something that integrates with or is invoked by
+it. Runs on Deno.
+
+## What it does
+
+- **Accepts worker registrations** — TS/Python/Rust/Go worker processes connect
+  over a Unix socket (the "sidecar") and announce which actors they serve.
+- **Owns its own Postgres connection and poll loop** — every 30 seconds
+  (default), asks Postgres which pending work matches its currently-registered
+  workers, with zero dependency on any external orchestrator's poll loop.
+- **Dispatches and archives** — for each claimed item, invokes the right worker
+  over the sidecar socket and archives the result.
+- **Optionally exposes a client-facing gRPC/Connect API** (`Invoke`,
+  `ListRegisteredActors`).
+
+Full flag reference, examples, and the PGMQ dispatch model behind this live in
+[`docs/guides/CLI-USAGE.md`](./docs/guides/CLI-USAGE.md); the goal-vs-current
+scoping record is [`GOAL.md`](./GOAL.md).
+
+## How to run
+
+```bash
+# From this package's directory
+deno task gateway
+deno task gateway-ctl -c list
+```
+
+### Via npx (no Deno required)
+
+```bash
+npx @pgfsm/async-worker async-operation-worker-gateway
+npx @pgfsm/async-worker async-operation-worker-gateway-ctl -c list
+```
+
+This package is published to npm as `@pgfsm/async-worker` with
+`async-operation-worker-gateway` and `async-operation-worker-gateway-ctl` `bin`
+entries, so each can be run via `npx`/`npm install -g` on plain Node — no Deno
+install needed.
+
+Those bin entries only exist because publishing goes through
+`deno task build:npm` (`scripts/build-npm.ts`, using `@deno/dnt`), which
+transpiles + Node-shims the source into `dist/` and registers the library export
+alongside the shebanged CLI bins in one pass. `deno pack` (used for this repo's
+other npm-published packages) does **not** synthesize a `package.json` `bin`
+field, so a CLI packed that way would be unreachable from `npx` —
+`.github/workflows/npm-publish.yml` builds this package's `async-worker` matrix
+entry through the dnt path instead.
+
+## Prerequisites
+
+- **Deno** (see `.prototools` for pinned version) — always required to run from
+  source
+- **Database connection** — `DATABASE_URL` in `.env`, or `--db-url`/`-d` passed
+  to the CLI (only needed for the poll loop; see `--disable-poll-loop` in
+  `CLI-USAGE.md`)
+- **At least one worker-sdk process** to register actors and actually serve
+  invocations — see `packages/fsm-proto-codegen/`'s generated stubs, or
+  `apps/fsm-core-example/worker-sdk-generated/<lang>/`
+
+## Key exports
+
+```typescript
+import {
+  ActivityGatewayClient, // invoke actors through the gateway's client-facing API
+  SidecarGateway, // the sidecar itself — worker registration + dispatch
+  startActivityGatewayServer, // sidecar + gRPC/Connect server + poll loop, all in one process
+  startAsyncOpPollLoop, // the 30s Postgres poll/claim/archive loop
+} from "@pgfsm/async-worker";
+```
+
+## Deno version
+
+Managed by `.prototools`. Install with:
+
+```bash
+proto install deno --pin local
+```

--- a/packages/fsm-core-async-op-worker/deno.json
+++ b/packages/fsm-core-async-op-worker/deno.json
@@ -1,22 +1,25 @@
 {
   "name": "@pgfsm/async-worker",
   "version": "0.1.0",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts"
   },
   "imports": {
+    "@bufbuild/protobuf": "npm:@bufbuild/protobuf@^1.10.1",
     "@connectrpc/connect": "npm:@connectrpc/connect@^1.7.0",
     "@connectrpc/connect-node": "npm:@connectrpc/connect-node@^1.7.0",
-    "@bufbuild/protobuf": "npm:@bufbuild/protobuf@^1.10.1",
-    "@logtape/logtape": "jsr:@logtape/logtape@^2.2",
+    "@deno/dnt": "jsr:@deno/dnt@^0.43.0",
+    "@logtape/logtape": "npm:@logtape/logtape@^2.2",
     "@std/cli": "jsr:@std/cli@1",
-    "pg": "npm:pg@^8.20.0",
-    "dotenv": "npm:dotenv@^16.5.0"
+    "@types/pg": "npm:@types/pg@^8.18.0",
+    "dotenv": "npm:dotenv@^16.5.0",
+    "pg": "npm:pg@^8.20.0"
   },
   "tasks": {
     "gateway": "deno run --allow-all src/cli/async-operation-worker-gateway.ts",
     "gateway-ctl": "deno run --allow-all src/cli/async-operation-worker-gateway-ctl.ts",
+    "build:npm": "deno run --allow-all scripts/build-npm.ts",
     "check": "deno check src/index.ts"
   }
 }

--- a/packages/fsm-core-async-op-worker/scripts/build-npm.ts
+++ b/packages/fsm-core-async-op-worker/scripts/build-npm.ts
@@ -1,0 +1,46 @@
+import { build, emptyDir } from "@deno/dnt";
+
+await emptyDir("./dist");
+
+await build({
+  entryPoints: [
+    "./src/index.ts",
+    {
+      kind: "bin",
+      name: "async-operation-worker-gateway",
+      path: "./src/cli/async-operation-worker-gateway.ts",
+    },
+    {
+      kind: "bin",
+      name: "async-operation-worker-gateway-ctl",
+      path: "./src/cli/async-operation-worker-gateway-ctl.ts",
+    },
+  ],
+  outDir: "./dist",
+  shims: {
+    deno: true,
+  },
+  package: {
+    name: "@pgfsm/async-worker",
+    version: Deno.args[0]?.replace(/^v/, "") ?? "0.0.0",
+    description:
+      "Activity Gateway (async-operation-worker-gateway/-ctl) for promise-type async FSM operations across polyglot actors",
+    license: "Apache-2.0",
+    // pg ships no types of its own; dnt only auto-installs packages that
+    // are themselves import specifiers, so without this the type-check
+    // pass can't resolve `import ... from "pg"` (deno.json's own
+    // "@types/pg" import mapping isn't picked up the same way here).
+    devDependencies: {
+      "@types/pg": "^8.18.0",
+    },
+  },
+  compilerOptions: {
+    lib: ["ES2022", "DOM"],
+    target: "ES2022",
+  },
+  postBuild() {
+    if (Deno.args.includes("--copy-readme")) {
+      Deno.copyFileSync("README.md", "dist/README.md");
+    }
+  },
+});


### PR DESCRIPTION
## Summary
Brings \`fsm-core-async-op-worker\` (\`@pgfsm/async-worker\`) in line with \`@pgfsm/sync-worker\` (#167) and \`@pgfsm/compiler\`'s npm-publish setup:

- Repoint the \`npm-publish.yml\` \`async-worker\` matrix entry from \`fsm-async-worker-ts\` (v1, never published, now \`@pgfsm/async-worker-old\` per #171) to this package, with \`dnt: true\` — ships both the library export and \`async-operation-worker-gateway\`/\`async-operation-worker-gateway-ctl\` as \`npx\`-able bins, instead of \`deno pack\`'s library-only output.
- Add \`scripts/build-npm.ts\` (dnt build script) + \`build:npm\` task, modeled on \`fsm-compiler-ts\`'s.
- Add \`README.md\` (needed for the \`--copy-readme\` step \`npm-publish.yml\` already runs for \`dnt\` packages) and a \`LICENSE\` file — this package had neither before.
- \`deno.json\`: \`license\` \`MIT\` → \`Apache-2.0\`, matching repo root and the new \`LICENSE\` file.
- \`@logtape/logtape\` switched from \`jsr:\` to \`npm:\` (has an npm release, same swap already made for sync-worker); \`@std/cli\` stays on \`jsr:\` (no npm distribution). Added \`@types/pg\` as a build-script \`devDependency\` since dnt's bundled type-check pulls in \`@pgfsm/db\` (which imports \`pg\` directly) through this package's own DB helper imports.

## Verification
Ran \`deno task build:npm 0.1.0 --copy-readme\` end to end — succeeded cleanly on the first try, including the \`@connectrpc\`/\`@bufbuild\` proto-codegen dependency graph that sync-worker's build didn't have to deal with (flagged as an open risk in #175, turned out fine).

Closes #175

## Test plan
- [x] \`deno task check\` — clean
- [x] \`deno task build:npm 0.1.0 --copy-readme\` — succeeded; verified \`dist/package.json\`'s \`bin\` map has both CLIs, dependencies resolved, README copied
- [x] \`deno fmt\` — clean
- [ ] Full green \`npm-publish\` CI run for \`async-worker\` (not run in this session — requires an actual tag push / workflow dispatch)