### PR TITLE
docs(worker-packages): make READMEs npm-consumer facing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ packages/
   fsm-compiler-ts/        # JSON → database object compiler (TypeScript) — see CLAUDE.md
   fsm-core-db-ts/         # Raw pg client helpers (TypeScript) — see CLAUDE.md
   fsm-sync-worker-ts/     # Worker fleet: fsmlet/fsmscheduler dispatch-queue CLIs — see CLAUDE.md
-  fsm-async-worker-ts/    # Worker fleet: async-operation-workerlet/scheduler dispatch-queue CLIs — see CLAUDE.md
+  fsm-core-async-op-worker/ # Activity Gateway: async-op worker-registration/dispatch CLIs (@pgfsm/async-worker) — see CLAUDE.md
+  fsm-async-worker-ts/    # Deprecated v1 async-op worker fleet (@pgfsm/async-worker-old); superseded by fsm-core-async-op-worker — see CLAUDE.md
   fsm-logging-ts/         # Shared LogTape logging config, @pgfsm/logging — see CLAUDE.md
   fsm-proto-codegen/      # Buf-driven multi-language proto stub generation — see CLAUDE.md
 ```

--- a/packages/fsm-compiler-ts/CLAUDE.md
+++ b/packages/fsm-compiler-ts/CLAUDE.md
@@ -13,8 +13,36 @@ deno task generate:fsm-types  # scripts/generate-fsm-json-types.ts
 deno task build:npm       # scripts/build-npm.ts (dnt npm build)
 ```
 
+Deno version is managed by `.prototools`: `proto install deno --pin local`.
+
 ## What it does
 
 Compiles `fsm.json` definitions into the PostgreSQL objects that drive
 instances. See `apps/fsm-core-example/CLAUDE.md` for the source FSM definition
-format this compiler consumes.
+format this compiler consumes. `README.md` is the npm/npx-consumer-facing
+document (published to `dist/` — see below); keep source-only detail here
+instead of there.
+
+## npm publish (`deno task build:npm`)
+
+`scripts/build-npm.ts` builds the npm package via `@deno/dnt`, not `deno pack`
+(used for this repo's other npm-published packages). `deno pack` does not
+synthesize a `package.json` `bin` field — per the Deno docs' "Limitations"
+section (https://docs.deno.com/runtime/reference/cli/pack/), it's
+library-publishing only, so a CLI packed that way would be unreachable from
+`npx`. dnt transpiles + Node-shims the source into `dist/`, registering both the
+library export and the shebanged `fsm-compiler` CLI bin.
+`.github/workflows/npm-publish.yml` builds this package's `compiler` matrix
+entry through the dnt path for that reason.
+
+`postBuild()` only copies `README.md` into `dist/` when `--copy-readme` is
+passed (`deno task build:npm <version> --copy-readme`, as CI does) — a plain
+local `deno task build:npm` skips it.
+
+dnt's Deno shim doesn't implement `Deno.Command` (unchecked in
+[shim-deno's PROGRESS.md](https://github.com/denoland/node_shims/blob/main/packages/shim-deno/PROGRESS.md)),
+so anything that shells out to a language runtime — actor validation
+(`validate-async-operation`) and the best-effort `deno fmt` pass on generated TS
+stubs — is unavailable in the npm/npx build. See `src/util.ts`'s `DenoCommand`
+export and its callers in `src/validate-async-operation-logic.ts` and
+`src/operation-logic-scaffold.ts`.

--- a/packages/fsm-compiler-ts/README.md
+++ b/packages/fsm-compiler-ts/README.md
@@ -1,71 +1,192 @@
-# fsm-compiler-ts — FSM Compiler
+# @pgfsm/compiler
 
-Validates FSM JSON definitions and generates polyglot plugin artifacts (actions,
-guards, delays, actor stubs) that workers load at startup. Runs on Deno.
+FSM JSON compiler for PostgreSQL-backed state machines: generates `fsm.json`
+from a folder of state machine definitions, scaffolds the action/guard/delay/
+actor stub code each language needs to implement, validates that every reference
+in the JSON has a matching implementation, and loads the compiled result into
+the database.
 
-## What it does
-
-**Input:** an `fsm.json` file in a versioned FSM folder\
-**Output:** a validated plugin — confirmed that every action, guard, delay, and
-actor referenced in the JSON has a matching export in its declared language
-
-Each actor is validated by calling its language's runtime directly:
-
-| Language     | Runtime called                               |
-| ------------ | -------------------------------------------- |
-| `typescript` | `deno run src/checkers/check_fn.ts`          |
-| `python`     | `python3 src/checkers/check_fn.py`           |
-| `go`         | `go build src/checkers/check_fn.go` → binary |
-| `rust`       | `rustc src/checkers/check_fn.rs` → binary    |
-
-Unresolved references are reported as errors so they're caught before
-deployment, not at runtime.
-
-## How to run
+## Install
 
 ```bash
-# Interactive CLI (dev mode with file watching)
-deno run --allow-all --watch src/main.ts
-
-# One-shot validation + generation
-deno run --allow-all src/main.ts
+npx @pgfsm/compiler --help
 ```
 
-### Via npx (no Deno required)
+or install it as a dependency / global CLI:
 
 ```bash
-npx @pgfsm/compiler --command <cmd> --folder <path> ...
+npm install @pgfsm/compiler
+npm install -g @pgfsm/compiler   # for a global `fsm-compiler` command
 ```
 
-This package is published to npm as `@pgfsm/compiler` with a `fsm-compiler`
-`bin` entry, so it can be run via `npx`/`npm install -g` on plain Node — no Deno
-install needed.
+## Usage
 
-That bin entry only exists because publishing goes through `deno task build:npm`
-(`scripts/build-npm.ts`, using `@deno/dnt`), which transpiles + Node-shims the
-source into `dist/` and registers both the library export and the shebanged CLI
-bin. `deno pack` (used for this repo's other npm-published packages) does
-**not** synthesize a `package.json` `bin` field — per the Deno docs' own
-"Limitations" section (https://docs.deno.com/runtime/reference/cli/pack/), it's
-library-publishing only. A CLI packed that way would be unreachable from `npx`,
-so `.github/workflows/npm-publish.yml` builds this package's `compiler` matrix
-entry through the dnt path instead.
+Run `npx @pgfsm/compiler --help` for the full flag reference. Every command
+below that takes `-f`/`--folder` for a directory applies the same rule to that
+path: it must **not** start with `.` (use a bare relative path like `fsm`, or an
+absolute path — not `./fsm`) and must **not** end with `/`.
 
-## Prerequisites
+### `generate` — compile `fsm.json` from a state machine definition
 
-- **Deno** (see `.prototools` for pinned version) — always required
-- **Python 3** (`python3` on `PATH`) — required when validating `python` actors
-- **Go** (`go` on `PATH`) — required when validating `go` actors
-- **Rust** (`rustc` on `PATH`) — required when validating `rust` actors
+**Input** — `-f`/`--folder` accepts either:
 
-## Key exports
+- A **plugin-root directory** containing one subfolder per FSM name, each with
+  version subfolders (`v01`, `v02`, …), each containing a `machine.ts` whose
+  default export is an XState machine (from `createMachine(...)`). Version
+  folders without a `machine.ts` are skipped, not an error.
+- A **single `.ts` file path** — only its containing directory is used; that
+  directory must contain a file literally named `machine.ts` (the filename you
+  pass is only used to locate the directory). The version name is taken from the
+  directory's own name, e.g. `.../creditCheck/v01/machine.ts` → `v01`.
+
+Other flags: `-w`/`--workflow-type`
+(`fsm | sharedFsm | sharedPromise |
+promise`, default `fsm`), `-s`/`--skip-dirs`
+(comma-separated FSM names to skip, directory mode only),
+`-r`/`--show-recommendation` (also validates the generated `fsm.json` against
+the FSM JSON schema and logs any errors — doesn't change what's written).
+
+**Output** — per version folder:
+
+- `xstate-fsm.json` — the machine's raw XState-exported JSON
+- `fsm.json` — that JSON normalized (actions coerced to `{ type }` objects,
+  raise/cancel delay names filled in, invoke actors' `fsmType`/`fsmVersion`
+  resolved). This is what every other command below reads.
+
+```bash
+npx @pgfsm/compiler -c generate -f fsm
+npx @pgfsm/compiler -c generate -f fsm -w sharedFsm --skip-dirs carVitals
+npx @pgfsm/compiler -c generate -f apps/fsm-core-example/fsm/creditCheck/v01/machine.ts
+```
+
+The full `fsm.json` spec (states, transitions, guards, actions, actors, delays)
+is documented in
+[`docs/reference/fsm-definition-format.md`](./docs/reference/fsm-definition-format.md).
+
+### `generate-sync-logic` — scaffold action/guard/delay stubs
+
+Reads each version folder's `fsm.json`, so `generate` must have already run.
+
+**Input** — `-f`/`--folder`: plugin-root directory (directory mode only, no
+single-file mode). `-l`/`--lang`: comma-separated `typescript,python,rust,go`
+(default `typescript`). `-s`/`--skip-dirs`.
+
+**Output** — per version folder, per requested language:
+
+- `<lang>/actions/index.{ts,py}` / `mod.rs` / `index.go` — one exported stub per
+  action name in `fsm.json` (built-in `xstate.raise`/`xstate.cancel` excluded)
+- `<lang>/guards/...` — one stub per guard
+- `<lang>/delays/...` — one stub per delay
+
+Every stub has a `// TODO: implement` body.
+
+```bash
+npx @pgfsm/compiler -c generate-sync-logic -f fsm --lang typescript,python
+```
+
+### `generate-async-logic` — scaffold actor stubs
+
+Reads each version folder's `fsm.json` (every `invoke` object), so `generate`
+must have already run.
+
+**Input** — `-f`/`--folder`: plugin-root directory.
+`-p`/`--worker-sdk-protocol`: `grpc` (default) or `legacy`. `-s`/`--skip-dirs`.
+
+**Output** — per version folder:
+
+- One file per distinct actor: `<lang>/actors/<name>/<name>.<ext>`, where
+  `<lang>` is that invoke object's own `fsmLanguage` (default `typescript`)
+- `actors-manifest.json` — every actor across all languages
+- A per-language barrel re-exporting each actor: `typescript/actors/index.ts`,
+  `python/actors/__init__.py`, `rust/actors/mod.rs` (Go has no barrel)
+- A per-language `generated-registry.*`, written only when that language has at
+  least one actor
+
+Once per app root (not per version folder), at
+`<appRoot>/worker-sdk-generated/<lang>/`: an aggregate registry plus worker SDK
+combining every FSM version's actors for that language — a worker process serves
+its language's actors across every FSM, not just one.
+
+```bash
+npx @pgfsm/compiler -c generate-async-logic -f fsm
+npx @pgfsm/compiler -c generate-async-logic -f fsm --worker-sdk-protocol legacy
+```
+
+### `create-async-logic` — scaffold one actor outside any FSM's `invoke` list
+
+For actors in the shared, non-FSM-scoped async-operation pool. For actors that
+belong to an FSM's `invoke` list, use `generate-async-logic` instead.
+
+**Input** — `-f`/`--folder`: the **app root** (one level above the FSM
+plugin-root directory — e.g. `apps/fsm-core-example`, not
+`apps/fsm-core-example/fsm`). `-l`/`--lang`: exactly one language, required.
+`-v`/`--version`: version name matching `v\d{2}` (e.g. `v01`), required.
+`-n`/`--name`: actor function name, required.
+
+**Output**:
+
+- `<appRoot>/shared-async-op/<version>/<lang>/actors/<name>/<name>.<ext>`
+- That language's registry file, rewritten from every actor currently on disk
+  under that folder (`typescript`/`python`/`rust` only — Go has no shared
+  registry)
+
+```bash
+npx @pgfsm/compiler -c create-async-logic -f apps/fsm-core-example --lang typescript --version v01 --name checkCreditScore
+```
+
+### `delete` — remove generated files
+
+**Input** — `-f`/`--folder`: plugin-root directory. `-w`/`--workflow-type`
+(default `fsm`). `-s`/`--skip-dirs`.
+
+**Output/side effect** — per version folder, removes `fsm.json`,
+`xstate-fsm.json`, and the `typescript/` and `python/` subdirectories if present
+(`rust/`/`go/` are left alone). Missing files are skipped silently, not an
+error.
+
+```bash
+npx @pgfsm/compiler -c delete -f fsm
+```
+
+### `validate-sync-operation` — check action/guard/delay stubs are implemented
+
+**Input** — `-f`/`--folder`: plugin-root directory. `-w`/`--workflow-type`:
+required. `-a`/`--available-actors`: path to a JSON file of
+`{ src, fsmType?, fsmVersion?, fsmLanguage? }[]` — actors resolvable from
+elsewhere (e.g. a shared pool) so invoke references pointing at them aren't
+reported as unresolved. `-s`/`--skip-dirs`.
+
+**Output** — writes nothing; validates that every action/guard/delay in
+`fsm.json` has a matching export in `<lang>/actions|guards|delays/index.*` and
+logs a pass/fail result per method.
+
+```bash
+npx @pgfsm/compiler -c validate-sync-operation -f fsm -w fsm
+```
+
+### `load` — load a compiled `fsm.json` into the database
+
+**Input** — `-f`/`--folder`: plugin-root directory (each version folder's
+`fsm.json` must already exist). `-w`/`--workflow-type`: required.
+`-d`/`--db-url` (or the `DATABASE_URL` env var). `-s`/`--skip-dirs`.
+
+**Output/side effect** — inserts each FSM's states/transitions into the
+`fsm_core` PostgreSQL schema, resolving `dependent_children` from any invoke
+actors whose `fsmType` is `"fsm"`. No local files are written.
+
+```bash
+npx @pgfsm/compiler -c load -f fsm -w fsm -d "$DATABASE_URL"
+```
+
+## Programmatic usage
 
 ```typescript
 import {
-  validateAndLoadFsmFromFolders, // validate all FSMs in a folder tree, then load if valid
-  validateAndLoadPromiseFromFolders, // validate all promise actors in a folder tree, then load if valid
-  validateAsyncOperationFromFolders, // validate actor exports per fsmLanguage, optionally filtered by lang
-  validateFsmPluginLoadFromFolder, // validate one specific FSM plugin
+  generateAsyncOperationLogicFromFolders, // scaffold actor stubs
+  generateFsmJSONFromFolders, // generate fsm.json for every FSM under a folder tree
+  generateSyncOperationLogicFromFolders, // scaffold action/guard/delay stubs
+  loadFsmJSONFromFolders, // load compiled fsm.json into the database
+  validateSyncOperationFromFolders, // check action/guard/delay stubs are implemented
 } from "@pgfsm/compiler";
 
 import type { OperationLang, WorkflowType } from "@pgfsm/compiler";
@@ -76,46 +197,6 @@ import type { OperationLang, WorkflowType } from "@pgfsm/compiler";
 The REST API and workers use these at startup to discover and validate FSM
 plugins before accepting requests.
 
-## Plugin structure
+## License
 
-After running the compiler against an FSM definition, the version folder
-contains:
-
-```
-fsm/<name>/v01/
-  fsm.json
-  xstate-fsm.json
-  typescript/
-    actions/index.ts              ← one export per action name in fsm.json
-    guards/index.ts               ← one export per guard name
-    delays/index.ts               ← one export per delay name
-    actors/promise_v01_<src>.ts   ← one file per actor, one export named <src>
-  python/
-    actors/promise_v01_<src>.py
-  rust/
-    actors/promise_v01_<src>.rs
-  go/
-    actors/promise_v01_<src>.go
-```
-
-Generated stubs have `// TODO: implement` bodies — fill them in before running a
-worker against the FSM.
-
-## Reference
-
-- [FSM definition format](./docs/fsm-definition-format.md) — full spec for
-  `fsm.json` (states, transitions, guards, actions, actors, delays)
-
-## Tests
-
-```bash
-deno test
-```
-
-## Deno version
-
-Managed by `.prototools`. Install with:
-
-```bash
-proto install deno --pin local
-```
+Apache-2.0

--- a/packages/fsm-compiler-ts/src/cli/index.ts
+++ b/packages/fsm-compiler-ts/src/cli/index.ts
@@ -71,7 +71,7 @@ COMMANDS
   create-async-logic                  Scaffold a single actor stub in the shared-async-op pool
   delete                              Delete generated fsm.json / xstate-fsm.json files
   validate-sync-operation             Validate sync operation logic (actions/guards/delays) for an FSM folder
-  validate-async-operation            Validate async operation logic (actors) for a sharedPromise folder
+  validate-async-operation            [DEPRECATED] Validate async operation logic (actors) for a sharedPromise folder — unsupported under the npm/npx build, requires the Deno-native CLI
   load                                Load FSM JSON into the database
 WORKFLOW TYPES
   fsm | sharedFsm | sharedPromise | promise
@@ -354,6 +354,9 @@ try {
       break;
     }
     case "validate-async-operation": {
+      logger.warn(
+        "validate-async-operation is deprecated: it shells out to each actor's own language runtime and only works under the Deno-native CLI, never via the npm/npx build.",
+      );
       const availableActors = await loadAvailableActors();
       await validateAsyncOperationFromFolders(
         folder!,

--- a/packages/fsm-core-async-op-worker/CLAUDE.md
+++ b/packages/fsm-core-async-op-worker/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md — Activity Gateway (`packages/fsm-core-async-op-worker/`)
+
+Scoped guidance for `@pgfsm/async-worker`. Repo-wide conventions and session
+protocol live in the root `CLAUDE.md` / `AGENTS.md`.
+
+## What it is
+
+The Activity Gateway for promise-type async FSM operations across polyglot
+(TypeScript/Python/Rust/Go) actors — a standalone alternative to
+`fsm-async-worker-ts` (v1, now `@pgfsm/async-worker-old`), not something that
+integrates with or is invoked by it. It owns its own poll/dispatch/archive loop
+end to end. Two CLIs: `async-operation-worker-gateway` (the long-running
+gateway/sidecar/poll-loop process) and `async-operation-worker-gateway-ctl` (a
+debug/test client). `README.md` is the npm/npx-consumer-facing document
+(published to `dist/` — see below); keep source-only detail here instead of
+there.
+
+Full flag reference, examples, and the PGMQ dispatch model live in
+[`docs/guides/CLI-USAGE.md`](./docs/guides/CLI-USAGE.md). The goal-vs-current
+scoping record (target behavior, comparison table, known gaps) is
+[`GOAL.md`](./GOAL.md) — a design/scoping note, not applied code changes.
+
+## Commands
+
+```bash
+deno task gateway      # async-operation-worker-gateway — start the gateway
+deno task gateway-ctl  # async-operation-worker-gateway-ctl — debug/test client
+deno task check        # deno check src/index.ts
+deno task build:npm    # scripts/build-npm.ts (dnt npm build)
+```
+
+Deno version is managed by `.prototools`: `proto install deno --pin local`.
+
+## npm publish (`deno task build:npm`)
+
+`scripts/build-npm.ts` builds the npm package via `@deno/dnt`, modeled on
+`fsm-compiler-ts`'s and `fsm-sync-worker-ts`'s build scripts — see
+`packages/fsm-compiler-ts/CLAUDE.md`'s "npm publish" section for why dnt (not
+`deno pack`) is required to ship CLI `bin` entries. Registers both the library
+export and the shebanged `async-operation-worker-gateway`/
+`async-operation-worker-gateway-ctl` bins. `.github/workflows/npm-publish.yml`'s
+`async-worker` matrix entry points at this package (repointed from
+`fsm-async-worker-ts`/v1 in #175/#176, once this package took over the
+`@pgfsm/async-worker` name in #171).
+
+`postBuild()` only copies `README.md` into `dist/` when `--copy-readme` is
+passed (`deno task build:npm <version> --copy-readme`, as CI does) — a plain
+local `deno task build:npm` skips it.
+
+This package also depends on `@pgfsm/proto-codegen` (generated
+Connect/protobuf/gRPC-Node code, `node:net` usage) — unlike sync-worker's dnt
+build, this one has to carry that dependency graph through dnt's type-check and
+bundling. Verified clean as of #176; if it breaks again, that's the first place
+to look.
+
+**Multi-bin `npx` gotcha**: because this package registers two bins and neither
+is named `async-worker` (the derived executable name from the package name), a
+plain `npx @pgfsm/async-worker async-operation-worker-gateway ...` does **not**
+work — npm can't determine which bin to run and errors
+`could
+not determine executable to run` (verified empirically against a scratch
+multi-bin package). The correct form is
+`npx -p @pgfsm/async-worker -- async-operation-worker-gateway ...` (or a real
+install, after which each bin is callable directly) — see `README.md`'s Install
+section, which documents this. Same issue applies to `fsm-sync-worker-ts` (four
+bins) — see its `CLAUDE.md`.
+
+## Structure (`src/`)
+
+- `cli/` — two CLI entry points (`async-operation-worker-gateway.ts`,
+  `async-operation-worker-gateway-ctl.ts`)
+- `gatewayServer.ts` — sidecar + gRPC/Connect server, wired together
+- `gatewayClient.ts` — client for the gRPC/Connect API (`ActivityGatewayClient`)
+- `sidecar/` — worker registration + dispatch over the Unix socket
+  (`SidecarGateway`)
+- `asyncOpPollLoop.ts` — the Postgres poll/claim/archive loop

--- a/packages/fsm-core-async-op-worker/README.md
+++ b/packages/fsm-core-async-op-worker/README.md
@@ -1,81 +1,121 @@
-# fsm-core-async-op-worker — Activity Gateway
+# @pgfsm/async-worker
 
 The Activity Gateway for promise-type async FSM operations across polyglot
-(TypeScript/Python/Rust/Go) actors — a standalone alternative to
-`fsm-async-worker-ts` (v1), not something that integrates with or is invoked by
-it. Runs on Deno.
+(TypeScript/Python/Rust/Go) actors: a standalone gateway process that accepts
+worker registrations over a Unix socket, polls Postgres for pending work
+matching those registrations, dispatches it to the right worker, and archives
+the result. Optionally exposes a client-facing gRPC/Connect `Invoke` API.
 
-## What it does
+## Install
 
-- **Accepts worker registrations** — TS/Python/Rust/Go worker processes connect
-  over a Unix socket (the "sidecar") and announce which actors they serve.
-- **Owns its own Postgres connection and poll loop** — every 30 seconds
-  (default), asks Postgres which pending work matches its currently-registered
-  workers, with zero dependency on any external orchestrator's poll loop.
-- **Dispatches and archives** — for each claimed item, invokes the right worker
-  over the sidecar socket and archives the result.
-- **Optionally exposes a client-facing gRPC/Connect API** (`Invoke`,
-  `ListRegisteredActors`).
-
-Full flag reference, examples, and the PGMQ dispatch model behind this live in
-[`docs/guides/CLI-USAGE.md`](./docs/guides/CLI-USAGE.md); the goal-vs-current
-scoping record is [`GOAL.md`](./GOAL.md).
-
-## How to run
+This package ships two CLI bins, so a plain `npx @pgfsm/async-worker` can't tell
+which one to run — pass `-p`/`--package` and name the bin after `--`:
 
 ```bash
-# From this package's directory
-deno task gateway
-deno task gateway-ctl -c list
+npx -p @pgfsm/async-worker -- async-operation-worker-gateway --help
 ```
 
-### Via npx (no Deno required)
+or install it as a dependency / global CLI, after which each bin is callable
+directly:
 
 ```bash
-npx @pgfsm/async-worker async-operation-worker-gateway
-npx @pgfsm/async-worker async-operation-worker-gateway-ctl -c list
+npm install @pgfsm/async-worker
+npm install -g @pgfsm/async-worker   # for global `async-operation-worker-gateway`/`-ctl` commands
 ```
 
-This package is published to npm as `@pgfsm/async-worker` with
-`async-operation-worker-gateway` and `async-operation-worker-gateway-ctl` `bin`
-entries, so each can be run via `npx`/`npm install -g` on plain Node — no Deno
-install needed.
+No Deno install is required to use the CLIs this way.
 
-Those bin entries only exist because publishing goes through
-`deno task build:npm` (`scripts/build-npm.ts`, using `@deno/dnt`), which
-transpiles + Node-shims the source into `dist/` and registers the library export
-alongside the shebanged CLI bins in one pass. `deno pack` (used for this repo's
-other npm-published packages) does **not** synthesize a `package.json` `bin`
-field, so a CLI packed that way would be unreachable from `npx` —
-`.github/workflows/npm-publish.yml` builds this package's `async-worker` matrix
-entry through the dnt path instead.
+## Usage
+
+Two CLIs ship in this package. Run either with `--help` for its full flag
+reference. Examples below assume a global install
+(`async-operation-worker-gateway ...`); via plain `npx` prefix each with
+`npx -p @pgfsm/async-worker --`.
+
+### `async-operation-worker-gateway` — start the gateway process
+
+**Input** — all flags optional:
+
+- `-b`/`--bind <target>` — gRPC bind target for the client-facing API (default
+  `unix:/tmp/pgfsm-activity-gateway.sock`)
+- `-s`/`--sidecar-socket <path>` — Unix socket worker processes connect to and
+  register actors on (default `/tmp/pgfsm-activity-gateway-workers.sock`)
+- `-t`/`--invoke-timeout-ms <ms>` — default per-invoke timeout (default `10000`)
+- `-d`/`--db-url <url>` — Postgres connection string (falls back to
+  `DATABASE_URL` from `.env`); required unless both `--disable-poll-loop` and
+  `--ensure-queue-on-register` are omitted/off
+- `--poll-interval-ms <ms>` — poll-loop interval (default `30000`)
+- `--disable-poll-loop` — run the gateway/sidecar only, no Postgres poll loop
+- `--ensure-queue-on-register` — also ensure a PGMQ queue exists for every actor
+  a worker registers (default off; best-effort — a name that exceeds PGMQ's
+  48-character limit fails only this step, not the registration)
+
+**Output/side effect** — starts a long-running process: a gRPC service
+(client-facing) backed by a Unix-socket sidecar (worker-facing), plus — unless
+disabled — its own Postgres poll loop that claims and dispatches pending
+promise-type async operations to whichever actors are currently registered, then
+archives each result. Runs until `SIGINT`/`SIGTERM` (a second signal
+force-exits).
+
+```bash
+async-operation-worker-gateway
+async-operation-worker-gateway --disable-poll-loop
+async-operation-worker-gateway --db-url "$DATABASE_URL" --ensure-queue-on-register
+```
+
+### `async-operation-worker-gateway-ctl` — debug/test client
+
+**Input** — first positional argument is the subcommand, `list` or `invoke`;
+`--target <target>` (default `unix:/tmp/pgfsm-activity-gateway.sock`) selects
+which running gateway to talk to.
+
+- `list` — no further flags.
+- `invoke` — requires `--parent-fsm-name`, `--parent-fsm-version`, `--fsm-type`,
+  `--fsm-name`, `--fsm-version`, `--fsm-language`; optional `--input <json>`
+  (default `null`), `--instance-id`/`--correlation-id` (default random UUIDs),
+  `--timeout-ms` (default `5000`).
+
+**Output** — writes nothing; `list` prints the actor keys currently registered
+with the target gateway, `invoke` calls that actor and prints its result JSON.
+
+```bash
+async-operation-worker-gateway-ctl list
+
+async-operation-worker-gateway-ctl invoke \
+  --parent-fsm-name creditCheck --parent-fsm-version v01 \
+  --fsm-type promise --fsm-name checkBureau --fsm-version v01 \
+  --fsm-language rust --input '{"ssn":"123"}'
+```
 
 ## Prerequisites
 
-- **Deno** (see `.prototools` for pinned version) — always required to run from
-  source
-- **Database connection** — `DATABASE_URL` in `.env`, or `--db-url`/`-d` passed
-  to the CLI (only needed for the poll loop; see `--disable-poll-loop` in
-  `CLI-USAGE.md`)
-- **At least one worker-sdk process** to register actors and actually serve
-  invocations — see `packages/fsm-proto-codegen/`'s generated stubs, or
-  `apps/fsm-core-example/worker-sdk-generated/<lang>/`
+- **A Postgres database** — `DATABASE_URL`, needed for the poll loop and/or
+  `--ensure-queue-on-register` (omit both to run the gateway/sidecar only)
+- **At least one worker-sdk process** connected to the sidecar socket, to
+  register actors and actually serve invocations — generate one from an FSM's
+  compiled actors (see `@pgfsm/compiler`'s `generate-async-logic`), or see
+  `apps/fsm-core-example/worker-sdk-generated/<lang>/` in the
+  [repo](https://github.com/pgfsm/fsm) for a worked example
 
-## Key exports
+## Programmatic usage
 
 ```typescript
 import {
   ActivityGatewayClient, // invoke actors through the gateway's client-facing API
   SidecarGateway, // the sidecar itself — worker registration + dispatch
   startActivityGatewayServer, // sidecar + gRPC/Connect server + poll loop, all in one process
-  startAsyncOpPollLoop, // the 30s Postgres poll/claim/archive loop
+  startAsyncOpPollLoop, // the poll/claim/archive loop, standalone
+} from "@pgfsm/async-worker";
+
+import type {
+  ActivityGatewayClientOptions,
+  AsyncOpPollLoopOptions,
+  GatewayServerOptions,
+  InvokeActorRequest,
+  InvokeActorResult,
 } from "@pgfsm/async-worker";
 ```
 
-## Deno version
+## License
 
-Managed by `.prototools`. Install with:
-
-```bash
-proto install deno --pin local
-```
+Apache-2.0

--- a/packages/fsm-sync-worker-ts/CLAUDE.md
+++ b/packages/fsm-sync-worker-ts/CLAUDE.md
@@ -31,7 +31,45 @@ deno task fsmscheduler # control-plane router (run once per cluster)
 deno task cli          # fsmctl — one-shot create/resume/send/stop
 deno task pgcron       # one-shot: (re)register the pg_cron drain job
 deno task check        # deno check src/index.ts
+deno task build:npm    # scripts/build-npm.ts (dnt npm build)
 ```
+
+Deno version is managed by `.prototools`: `proto install deno --pin local`.
+`README.md` is the npm/npx-consumer-facing document (published to `dist/` — see
+below); keep source-only detail here instead of there.
+
+## npm publish (`deno task build:npm`)
+
+`scripts/build-npm.ts` builds the npm package via `@deno/dnt`, not `deno pack`
+(used for this repo's other npm-published packages) — see
+`packages/fsm-compiler-ts/CLAUDE.md`'s "npm publish" section for why dnt is
+required to ship CLI `bin` entries. Registers the library export alongside four
+shebanged bins (`fsmlet`, `fsmscheduler`, `fsmctl`, `pgcron`) in one pass.
+`.github/workflows/npm-publish.yml` builds this package's `sync-worker` matrix
+entry through the dnt path.
+
+`postBuild()` only copies `README.md` into `dist/` when `--copy-readme` is
+passed (`deno task build:npm <version> --copy-readme`, as CI does) — a plain
+local `deno task build:npm` skips it.
+
+**Multi-bin `npx` gotcha**: because this package registers four bins and none of
+them is named `sync-worker` (the derived executable name from the package name),
+a plain `npx @pgfsm/sync-worker fsmlet ...` does **not** work — npm can't
+determine which bin to run and errors `could not determine executable
+to run`
+(verified empirically against a scratch multi-bin package). The correct form is
+`npx -p @pgfsm/sync-worker -- fsmlet ...` (or a real install, after which each
+bin is callable directly) — see `README.md`'s Install section, which documents
+this.
+
+**Known issue**: as of the last check, `deno task build:npm` fails its
+type-check pass with `TS2345` errors in `src/fsmlet/fsmlet.ts` around
+`asyncActors` — `ActorReference[]` (from `@pgfsm/compiler`) isn't assignable to
+the `AsyncActor[]` dnt's bundled compiler expects, because
+`ActorReference.fsmVersion` is `string | undefined` while `AsyncActor`
+presumably wants `string`. Not caused by anything in this doc pass; reproduce
+with `deno task build:npm 0.0.0 --copy-readme` before assuming a docs/README
+change broke it.
 
 ## Structure (`src/`)
 

--- a/packages/fsm-sync-worker-ts/README.md
+++ b/packages/fsm-sync-worker-ts/README.md
@@ -1,62 +1,135 @@
-# fsm-sync-worker-ts — Worker Fleet
+# @pgfsm/sync-worker
 
-The out-of-band worker fleet that drives FSM instances forward (the HTTP API
-never blocks on or owns worker lifecycle). Runs on Deno.
+The out-of-band worker fleet that drives FSM instances forward — the HTTP API
+never blocks on or owns worker lifecycle. Kubernetes-style split: `fsmlet`
+(kubelet — long-running node agent) is routed work by `fsmscheduler`
+(kube-scheduler — control plane, run once per cluster), driven one-shot by
+`fsmctl`; `pgcron` is a one-shot deploy-time alternative to running a standing
+`fsmscheduler`.
 
-## What it does
+## Install
 
-Kubernetes-style split:
-
-| CLI              | Role                                                                            |
-| ---------------- | ------------------------------------------------------------------------------- |
-| **fsmlet**       | Long-running node agent (kubelet equivalent) — claims and drives FSM workers    |
-| **fsmscheduler** | Control-plane routing process (kube-scheduler equivalent), run once per cluster |
-| **fsmctl**       | One-shot control CLI (kubectl equivalent) — create/resume/send/stop             |
-| **pgcron**       | One-shot deploy-time script — (re)registers the `pg_cron` drain job             |
-
-Full flag reference, examples, and the dispatch model behind these four CLIs
-live in [`docs/guides/CLI-USAGE.md`](./docs/guides/CLI-USAGE.md).
-
-## How to run
+This package ships four CLI bins, so a plain `npx @pgfsm/sync-worker` can't tell
+which one to run — pass `-p`/`--package` and name the bin after `--`:
 
 ```bash
-# From this package's directory
-deno task fsmlet -f <fsm-folder-path>
-deno task fsmscheduler
-deno task cli -c create -n <fsm-name> -v <fsm-version>
-deno task pgcron
+npx -p @pgfsm/sync-worker -- fsmlet --help
 ```
 
-### Via npx (no Deno required)
+or install it as a dependency / global CLI, after which each bin is callable
+directly:
 
 ```bash
-npx @pgfsm/sync-worker fsmlet -f <fsm-folder-path>
-npx @pgfsm/sync-worker fsmscheduler
-npx @pgfsm/sync-worker fsmctl -c create -n <fsm-name> -v <fsm-version>
-npx @pgfsm/sync-worker pgcron
+npm install @pgfsm/sync-worker
+npm install -g @pgfsm/sync-worker   # for global fsmlet/fsmscheduler/fsmctl/pgcron commands
 ```
 
-This package is published to npm as `@pgfsm/sync-worker` with `fsmlet`,
-`fsmscheduler`, `fsmctl`, and `pgcron` `bin` entries, so each can be run via
-`npx`/`npm install -g` on plain Node — no Deno install needed.
+No Deno install is required to use the CLIs this way.
 
-Those bin entries only exist because publishing goes through
-`deno task build:npm` (`scripts/build-npm.ts`, using `@deno/dnt`), which
-transpiles + Node-shims the source into `dist/` and registers the library export
-alongside the shebanged CLI bins in one pass. `deno pack` (used for this repo's
-other npm-published packages) does **not** synthesize a `package.json` `bin`
-field, so a CLI packed that way would be unreachable from `npx` —
-`.github/workflows/npm-publish.yml` builds this package's `sync-worker` matrix
-entry through the dnt path instead.
+## Usage
+
+Four CLIs ship in this package. Run any of them with `--help` for its full flag
+reference. Examples below assume a global install (`fsmlet ...`); via plain
+`npx` prefix each with `npx -p @pgfsm/sync-worker --`.
+
+### `fsmlet` — node agent (kubelet equivalent)
+
+**Input** — `-f`/`--fsm-folder-path <path>`: absolute path to the compiled FSM
+folder, required. `-d`/`--db-url <url>` (falls back to `DATABASE_URL`).
+`-m`/`--max-concurrency <n>`: max FSM instances driven concurrently (default
+`8`). `-i`/`--fsmlet-id <id>`: stable identity (falls back to `FSMLET_ID` env,
+then a random UUID per startup).
+
+**Output/side effect** — starts a long-running process: registers itself in
+`fsm_daemon_node`, creates its private pgmq queues, then polls
+`daemon_{id}_start`/`daemon_{id}_resume` for work `fsmscheduler` routes to it
+based on module availability and capacity. Sends a heartbeat every 5s so the
+scheduler can score this node. Deregisters cleanly on shutdown
+(`SIGINT`/`SIGTERM`; a second signal force-exits).
+
+```bash
+fsmlet -f /abs/path/to/fsm
+fsmlet -f /abs/path/to/fsm --max-concurrency 16 --fsmlet-id worker-1
+```
+
+### `fsmscheduler` — control-plane router (kube-scheduler equivalent)
+
+Run once per cluster, on the control plane alongside the API server — **not** on
+`fsmlet` nodes. `pgcron` (below) is an alternative to running this as a standing
+process.
+
+**Input** — `-d`/`--db-url <url>` (falls back to `DATABASE_URL`, required).
+`-p`/`--poll-interval <ms>`: fallback poll interval (default `30000`).
+`-s`/`--stale-threshold <secs>`: seconds before an `fsmlet` is considered dead
+(default `30`).
+
+**Output/side effect** — starts a long-running process: listens on the
+`fsm_scheduler_work` `pg_notify` channel; when a dispatch entry appears in
+`fsm_dispatch_queue`, runs a scheduling cycle (`SELECT FOR UPDATE SKIP
+LOCKED`,
+filter+score active `fsmlet`s, mark `scheduled`, `pg_notify` the winning
+`fsmlet`), plus a fallback poll for missed notifications.
+
+```bash
+fsmscheduler
+fsmscheduler --poll-interval 10000 --stale-threshold 15
+```
+
+### `fsmctl` — one-shot control CLI (kubectl equivalent)
+
+**Input** — `-c`/`--command <command>`, required: `create`, `resume`, `send`, or
+`stop`.
+
+- `create` — requires `-n`/`--fsm-name`, `-v`/`--fsm-version`; optional
+  `--context <json>` (initial FSM context, default `{}`)
+- `resume` / `stop` — require `-q`/`--queue-name <instance-id>`
+- `send` — requires `-q`/`--queue-name` and `-e`/`--event-type`; optional
+  `--event-data <json>` (default `{}`)
+
+`-d`/`--db-url <url>` (falls back to `DATABASE_URL`) applies to all commands.
+
+**Output/side effect** —
+
+- `create`: creates a new FSM instance and its pgmq queue, enqueues it to
+  `fsm_dispatch_queue`, and prints the created instance
+- `resume`: re-enqueues an existing instance to `fsm_dispatch_queue`
+- `send`: sends an event to a running instance's queue
+- `stop`: sends a stop signal to the instance's worker via `pg_notify`
+
+```bash
+fsmctl -c create -n creditCheck -v 1
+fsmctl -c create -n creditCheck -v 1 --context '{"userId":"abc"}'
+fsmctl -c resume -q <instance-uuid>
+fsmctl -c send -q <instance-uuid> -e APPROVE --event-data '{"reason":"ok"}'
+fsmctl -c stop -q <instance-uuid>
+```
+
+### `pgcron` — one-shot deploy-time script
+
+An **alternative** to running `fsmscheduler` as a standing process, not
+something you also need to run alongside it.
+
+**Input** — `-d`/`--db-url <url>` (falls back to `DATABASE_URL`, required).
+`-s`/`--schedule <cron>`: pg_cron schedule expression (default `"5 seconds"`).
+
+**Output/side effect** — idempotently (re)registers the
+`fsm_schedule_all_pending` `pg_cron` job, which calls
+`fsm_core.schedule_all_pending()` on the given schedule to drain the FSM
+dispatch queue. Unschedules any pre-existing job with this name first, so it's
+safe to re-run. Run once as a deploy-time step after applying migrations, or
+whenever the schedule needs to change — `pg_cron`'s job registration is a
+data-level side effect that a structural schema-diff migration can't capture.
+
+```bash
+pgcron
+pgcron --schedule "10 seconds"
+```
 
 ## Prerequisites
 
-- **Deno** (see `.prototools` for pinned version) — always required to run from
-  source
-- **Database connection** — `DATABASE_URL` in `.env`, or `--db-url`/`-d` passed
-  to any CLI
+- **A Postgres database** — `DATABASE_URL`, or `--db-url`/`-d` passed to any CLI
 
-## Key exports
+## Programmatic usage
 
 ```typescript
 import {
@@ -65,12 +138,10 @@ import {
   startFSMWorker, // drive a single FSM instance
   startFSMWorkerWithDBLock, // same, holding a DB-level advisory lock
 } from "@pgfsm/sync-worker";
+
+import type { FsmletOptions, FsmSchedulerOptions } from "@pgfsm/sync-worker";
 ```
 
-## Deno version
+## License
 
-Managed by `.prototools`. Install with:
-
-```bash
-proto install deno --pin local
-```
+Apache-2.0


### PR DESCRIPTION
## Summary
- `fsm-compiler-ts/README.md` rewritten as npm/npx-consumer facing, with a per-subcommand `## Usage` section (`generate`, `generate-sync-logic`, `generate-async-logic`, `create-async-logic`, `delete`, `validate-sync-operation`, `load`) covering real input/output per command; dev-only detail (dnt build rationale, `--copy-readme` flag) moved to `CLAUDE.md`.
- CLI: `validate-async-operation` marked `[DEPRECATED]` in `--help` output plus a runtime warning — unsupported under the npm/npx build (shells out to each actor language's own runtime).
- `fsm-sync-worker-ts/README.md` and `fsm-core-async-op-worker/README.md` get the same treatment — per-CLI `## Usage` sections, dev detail moved to (new, for async-op-worker) `CLAUDE.md`.
- Fixed a real `npx` bug found while writing these: packages with more than one `bin` entry (sync-worker has 4, async-op-worker has 2) can't be invoked as `npx @pkg <bin-name> ...` — npm errors `could not determine executable to run` unless a bin name matches the derived package name. Verified against a scratch multi-bin package. Both READMEs now document the correct `npx -p @pkg -- <bin> ...` form.
- Root `CLAUDE.md` package table updated: it didn't list `fsm-core-async-op-worker` (the active `@pgfsm/async-worker`, post-#171 rename) at all, and described `fsm-async-worker-ts` as if still current instead of the deprecated v1.

Closes #177

## Test plan
- [x] `deno fmt --check` — clean
- [x] `npx @pgfsm/compiler ...` single-bin invocation verified (compiler CLI run directly, `--help`/deprecation warning output confirmed)
- [x] Multi-bin `npx` claim verified empirically against a scratch two-bin npm package (`could not determine executable to run` without `-p`/`--package`)
- [ ] Full `npm-publish` CI dry run for all three packages (not run in this session)