### PR TITLE
chore(compiler-ts): remove unused workflowType param from compiler helper functions

### DIFF
--- a/packages/fsm-compiler-ts/README.md
+++ b/packages/fsm-compiler-ts/README.md
@@ -39,12 +39,10 @@ absolute path — not `./fsm`) and must **not** end with `/`.
   pass is only used to locate the directory). The version name is taken from the
   directory's own name, e.g. `.../creditCheck/v01/machine.ts` → `v01`.
 
-Other flags: `-w`/`--workflow-type`
-(`fsm | sharedFsm | sharedPromise |
-promise`, default `fsm`), `-s`/`--skip-dirs`
-(comma-separated FSM names to skip, directory mode only),
-`-r`/`--show-recommendation` (also validates the generated `fsm.json` against
-the FSM JSON schema and logs any errors — doesn't change what's written).
+Other flags: `-s`/`--skip-dirs` (comma-separated FSM names to skip, directory
+mode only), `-r`/`--show-recommendation` (also validates the generated
+`fsm.json` against the FSM JSON schema and logs any errors — doesn't change
+what's written).
 
 **Output** — per version folder:
 
@@ -55,7 +53,7 @@ the FSM JSON schema and logs any errors — doesn't change what's written).
 
 ```bash
 npx @pgfsm/compiler -c generate -f fsm
-npx @pgfsm/compiler -c generate -f fsm -w sharedFsm --skip-dirs carVitals
+npx @pgfsm/compiler -c generate -f fsm --skip-dirs carVitals
 npx @pgfsm/compiler -c generate -f apps/fsm-core-example/fsm/creditCheck/v01/machine.ts
 ```
 
@@ -136,8 +134,7 @@ npx @pgfsm/compiler -c create-async-logic -f apps/fsm-core-example --lang typesc
 
 ### `delete` — remove generated files
 
-**Input** — `-f`/`--folder`: plugin-root directory. `-w`/`--workflow-type`
-(default `fsm`). `-s`/`--skip-dirs`.
+**Input** — `-f`/`--folder`: plugin-root directory. `-s`/`--skip-dirs`.
 
 **Output/side effect** — per version folder, removes `fsm.json`,
 `xstate-fsm.json`, and the `typescript/` and `python/` subdirectories if present

--- a/packages/fsm-compiler-ts/src/cli/index.ts
+++ b/packages/fsm-compiler-ts/src/cli/index.ts
@@ -296,7 +296,6 @@ try {
           await generateFsmJSONFromMachineFile(
             absDir,
             version,
-            workflowType ?? "fsm",
             args["show-recommendation"],
           );
         } else {
@@ -309,7 +308,6 @@ try {
       } else {
         await generateFsmJSONFromFolders(
           folder!,
-          workflowType ?? "fsm",
           skipDirs,
           args["show-recommendation"],
         );

--- a/packages/fsm-compiler-ts/src/cli/index.ts
+++ b/packages/fsm-compiler-ts/src/cli/index.ts
@@ -79,7 +79,7 @@ WORKFLOW TYPES
 OPTIONS
   -c, --command <command>             Command to run (required)
   -f, --folder <folder>               Path to FSM folder or .ts file (required; a .ts file is accepted for generate only; app root for create-async-logic)
-  -w, --workflow-type <type>          Workflow type (optional for generate-sync-logic, defaults to "fsm"; required for validate-sync-operation, load)
+  -w, --workflow-type <type>          Workflow type (required for validate-sync-operation, load)
   -l, --lang <langs>                  Comma-separated language(s): typescript, python, rust, go. For generate-sync-logic defaults to typescript; for validate-async-operation defaults to all languages; for create-async-logic a single language is required
   -v, --version <version>             FSM version folder name, e.g. v01 (create-async-logic only, required)
   -n, --name <name>                   Actor function name, used for <name>/<name>.ext (create-async-logic only, required)
@@ -322,7 +322,6 @@ try {
     case "generate-sync-logic":
       await generateSyncOperationLogicFromFolders(
         folder!,
-        workflowType ?? "fsm",
         langs,
         skipDirs,
       );

--- a/packages/fsm-compiler-ts/src/cli/index.ts
+++ b/packages/fsm-compiler-ts/src/cli/index.ts
@@ -214,7 +214,6 @@ if (workflowType && !VALID_WORKFLOW_TYPES.includes(workflowType)) {
 
 const needsWorkflowType = [
   "validate-sync-operation",
-  "validate-async-operation",
   "load",
 ];
 
@@ -317,7 +316,6 @@ try {
     case "generate-async-logic":
       await generateAsyncOperationLogicFromFolders(
         folder!,
-        workflowType ?? "fsm",
         skipDirs,
         workerSdkProtocol,
       );
@@ -339,7 +337,7 @@ try {
       );
       break;
     case "delete":
-      await deleteFsmJSONFromFolders(folder!, workflowType ?? "fsm", skipDirs);
+      await deleteFsmJSONFromFolders(folder!, skipDirs);
       break;
     case "validate-sync-operation": {
       const availableActors = await loadAvailableActors();
@@ -358,7 +356,6 @@ try {
       const availableActors = await loadAvailableActors();
       await validateAsyncOperationFromFolders(
         folder!,
-        workflowType!,
         skipDirs,
         availableActors,
         validateLangs,

--- a/packages/fsm-compiler-ts/src/cli/index.ts
+++ b/packages/fsm-compiler-ts/src/cli/index.ts
@@ -79,7 +79,7 @@ WORKFLOW TYPES
 OPTIONS
   -c, --command <command>             Command to run (required)
   -f, --folder <folder>               Path to FSM folder or .ts file (required; a .ts file is accepted for generate only; app root for create-async-logic)
-  -w, --workflow-type <type>          Workflow type (optional for generate, generate-async-logic, generate-sync-logic, delete, defaults to "fsm"; required for validate-sync-operation, validate-async-operation, load)
+  -w, --workflow-type <type>          Workflow type (optional for generate-sync-logic, defaults to "fsm"; required for validate-sync-operation, load)
   -l, --lang <langs>                  Comma-separated language(s): typescript, python, rust, go. For generate-sync-logic defaults to typescript; for validate-async-operation defaults to all languages; for create-async-logic a single language is required
   -v, --version <version>             FSM version folder name, e.g. v01 (create-async-logic only, required)
   -n, --name <name>                   Actor function name, used for <name>/<name>.ext (create-async-logic only, required)
@@ -95,7 +95,6 @@ ENVIRONMENT
 
 EXAMPLES
   deno run --allow-all src/cli/index.ts -c generate -f apps/fsm-core-example/fsm
-  deno run --allow-all src/cli/index.ts -c generate -f apps/fsm-core-example/fsm -w sharedFsm
   deno run --allow-all src/cli/index.ts -c generate -f apps/fsm-core-example/fsm --skip-dirs carVitals,taskMachineConfig
   deno run --allow-all src/cli/index.ts -c generate -f apps/fsm-core-example/fsm/creditCheck/v01/machine.ts
   deno run --allow-all src/cli/index.ts -c generate-async-logic -f apps/fsm-core-example/fsm
@@ -103,9 +102,9 @@ EXAMPLES
   deno run --allow-all src/cli/index.ts -c generate-sync-logic -f apps/fsm-core-example/fsm --lang typescript,python
   deno run --allow-all src/cli/index.ts -c create-async-logic -f apps/fsm-core-example --lang typescript --version v01 --name checkCreditScore
   deno run --allow-all src/cli/index.ts -c validate-sync-operation -f apps/fsm-core-example/fsm -w fsm
-  deno run --allow-all src/cli/index.ts -c validate-async-operation -f apps/fsm-core-example/fsm -w sharedPromise --skip-dirs carVitals,creditCheck,taskMachineConfig
-  deno run --allow-all src/cli/index.ts -c validate-async-operation -f apps/fsm-core-example/fsm -w sharedPromise --skip-dirs carVitals,creditCheck,taskMachineConfig --lang typescript
-  deno run --allow-all src/cli/index.ts -c validate-async-operation -f apps/fsm-core-example/fsm -w sharedPromise --skip-dirs carVitals,creditCheck,taskMachineConfig --lang typescript,python
+  deno run --allow-all src/cli/index.ts -c validate-async-operation -f apps/fsm-core-example/fsm --skip-dirs carVitals,creditCheck,taskMachineConfig
+  deno run --allow-all src/cli/index.ts -c validate-async-operation -f apps/fsm-core-example/fsm --skip-dirs carVitals,creditCheck,taskMachineConfig --lang typescript
+  deno run --allow-all src/cli/index.ts -c validate-async-operation -f apps/fsm-core-example/fsm --skip-dirs carVitals,creditCheck,taskMachineConfig --lang typescript,python
 `);
 }
 

--- a/packages/fsm-compiler-ts/src/delete-fsm-json-from-folders-test.ts
+++ b/packages/fsm-compiler-ts/src/delete-fsm-json-from-folders-test.ts
@@ -20,7 +20,6 @@ dotenv.config({ path: "./../../.env" });
   // const skipFSMDirs = [];
   await deleteFsmJSONFromFolders(
     fsmfolderPath,
-    "fsm",
     skipFSMDirs,
   );
 })();

--- a/packages/fsm-compiler-ts/src/delete-fsm-json-from-folders.ts
+++ b/packages/fsm-compiler-ts/src/delete-fsm-json-from-folders.ts
@@ -1,7 +1,7 @@
 import { getLogger } from "@logtape/logtape";
 
 const logger = getLogger(["@pgfsm/compiler", "delete"]);
-import { isVersionFolderName, type WorkflowType } from "./util.ts";
+import { isVersionFolderName } from "./util.ts";
 
 async function deleteFsmJSONFromFolder(
   dirEntryName: string,
@@ -9,7 +9,6 @@ async function deleteFsmJSONFromFolder(
   _folderPath: string,
   absFolderPath: string,
   _parentSource: string,
-  _workflowType: WorkflowType,
 ) {
   try {
     await Deno.remove(`${absFolderPath}/xstate-fsm.json`);
@@ -38,7 +37,6 @@ async function deleteFsmJSONFromFolder(
 
 export async function deleteFsmJSONFromFolders(
   folderPath: string,
-  workflowType: WorkflowType,
   skipDirs: string[] = [],
 ) {
   if (folderPath.startsWith(".")) {
@@ -81,7 +79,6 @@ export async function deleteFsmJSONFromFolders(
               folderPath,
               `${fsmDirPath}/${subEntry.name}`,
               dirEntry.name,
-              workflowType,
             );
           } else {
             logger.info("Skipping non-timestamped folder: {name} in {dir}", {

--- a/packages/fsm-compiler-ts/src/generate-async-operation-logic-test.ts
+++ b/packages/fsm-compiler-ts/src/generate-async-operation-logic-test.ts
@@ -11,7 +11,6 @@ dotenv.config({ path: "./../../.env" });
   // Async operation logic (actors) — routed by each invoke's fsmLanguage.
   await generateAsyncOperationLogicFromFolders(
     fsmfolderPath,
-    "fsm",
     skipFSMDirs,
   );
 })();

--- a/packages/fsm-compiler-ts/src/generate-async-operation-logic.ts
+++ b/packages/fsm-compiler-ts/src/generate-async-operation-logic.ts
@@ -1,5 +1,5 @@
 import { getLogger } from "@logtape/logtape";
-import { extractFsmPluginRefs, type WorkflowType } from "./util.ts";
+import { extractFsmPluginRefs } from "./util.ts";
 import {
   actorFileBaseName,
   type ActorsBarrelLang,
@@ -69,7 +69,6 @@ const BARREL_LANGS: ActorsBarrelLang[] = ["typescript", "python", "rust"];
  */
 export async function generateAsyncOperationLogicFromFolders(
   folderPath: string,
-  _workflowType: WorkflowType,
   skipDirs: string[] = [],
   workerSdkProtocol: WorkerSdkProtocol = "grpc",
 ): Promise<void> {

--- a/packages/fsm-compiler-ts/src/generate-fsm-json-test.ts
+++ b/packages/fsm-compiler-ts/src/generate-fsm-json-test.ts
@@ -14,7 +14,7 @@ const fsmfolderPath = "apps/fsm-core-example/fsm";
 
   const skipFSMDirs = ["carVitals", "taskMachineConfig", "vitalsWorkflow"];
   logger.info("--- generate fsm (showRecommendation = true) ---");
-  await generateFsmJSONFromFolders(fsmfolderPath, "fsm", skipFSMDirs, true);
+  await generateFsmJSONFromFolders(fsmfolderPath, skipFSMDirs, true);
   logger.info("fsm generated with recommendation");
 
   logger.info("=== generateFsmJSON tests complete ===");

--- a/packages/fsm-compiler-ts/src/generate-fsm-json.ts
+++ b/packages/fsm-compiler-ts/src/generate-fsm-json.ts
@@ -10,7 +10,6 @@ import {
   DELAY_ACTION_NAME_PREFIX,
   isVersionFolderName,
   RAISE_CANCEL,
-  type WorkflowType,
 } from "./util.ts";
 import type { AnyStateNodeDefinition } from "xstate";
 import type {
@@ -342,13 +341,11 @@ export function addMissingFsmTypeToInvokeActors(
  * and writes fsm.json + xstate-fsm.json alongside it.
  * @param absFolderPath Absolute path to the versioned FSM directory (e.g. /…/creditCheck/v01)
  * @param version Version string (e.g. "v01") used when filling in missing fsmVersion on invoke actors
- * @param workflowType Workflow type for the FSM
  * @param showRecommendation When true, validates fsm.json against the machine schema and logs issues
  */
 export async function generateFsmJSONFromMachineFile(
   absFolderPath: string,
   version: string,
-  _workflowType: WorkflowType,
   showRecommendation: boolean = false,
 ) {
   const machineTsPath = `${absFolderPath}/machine.ts`;
@@ -433,20 +430,17 @@ async function generateFsmJSONFromFolder(
   _folderPath: string,
   absFolderPath: string,
   _parentSource: string,
-  workflowType: WorkflowType,
   showRecommendation: boolean = false,
 ) {
   await generateFsmJSONFromMachineFile(
     absFolderPath,
     dirEntryNameVersion,
-    workflowType,
     showRecommendation,
   );
 }
 
 export async function generateFsmJSONFromFolders(
   folderPath: string,
-  workflowType: WorkflowType,
   skipDirs: string[] = [],
   showRecommendation: boolean = false,
 ) {
@@ -490,7 +484,6 @@ export async function generateFsmJSONFromFolders(
               folderPath,
               `${fsmDirPath}/${subEntry.name}`,
               dirEntry.name,
-              workflowType,
               showRecommendation,
             );
           } else {

--- a/packages/fsm-compiler-ts/src/generate-sync-operation-logic-test.ts
+++ b/packages/fsm-compiler-ts/src/generate-sync-operation-logic-test.ts
@@ -10,7 +10,6 @@ dotenv.config({ path: "./../../.env" });
   // Sync operation logic (actions/guards/delays) — generated in TypeScript.
   await generateSyncOperationLogicFromFolders(
     fsmfolderPath,
-    "fsm",
     ["typescript"],
     skipFSMDirs,
   );

--- a/packages/fsm-compiler-ts/src/generate-sync-operation-logic.ts
+++ b/packages/fsm-compiler-ts/src/generate-sync-operation-logic.ts
@@ -1,9 +1,5 @@
 import { getLogger } from "@logtape/logtape";
-import {
-  extractFsmPluginRefs,
-  RAISE_CANCEL,
-  type WorkflowType,
-} from "./util.ts";
+import { extractFsmPluginRefs, RAISE_CANCEL } from "./util.ts";
 import {
   eachVersionedFsmFolder,
   type OperationLang,
@@ -23,7 +19,6 @@ const logger = getLogger(["@pgfsm/compiler", "sync-logic"]);
  */
 export async function generateSyncOperationLogicFromFolders(
   folderPath: string,
-  _workflowType: WorkflowType,
   langs: OperationLang[],
   skipDirs: string[] = [],
 ): Promise<void> {

--- a/packages/fsm-compiler-ts/src/validate-async-operation-logic.ts
+++ b/packages/fsm-compiler-ts/src/validate-async-operation-logic.ts
@@ -16,7 +16,6 @@ import {
   type ActorReference,
   DenoCommand,
   isVersionFolderName,
-  type WorkflowType,
 } from "./util.ts";
 
 /**
@@ -32,7 +31,6 @@ const DENO_COMMAND_UNAVAILABLE_MESSAGE =
 
 export async function validateAsyncOperationFromFolders(
   folderPath: string,
-  _workflowType: WorkflowType,
   skipDirs: string[] = [],
   _availableActors: ActorReference[] = [],
   runtimeLanguages: OperationLang[] = [],

--- a/packages/fsm-compiler-ts/test/generate-fsm-json.test.ts
+++ b/packages/fsm-compiler-ts/test/generate-fsm-json.test.ts
@@ -227,7 +227,7 @@ const FSM_FOLDER = `${APP_ROOT}/fsm`;
 const SHARED_FSM_SKIP_DIRS = ["carVitals", "creditCheck", "taskMachineConfig"];
 
 Deno.test("generateFsmJSONFromFolders - generates fsm.json for fsm folder", async () => {
-  await generateFsmJSONFromFolders(FSM_FOLDER, "fsm", []);
+  await generateFsmJSONFromFolders(FSM_FOLDER, []);
 
   const stat = await Deno.stat(`${FSM_FOLDER}/creditCheck/v01/fsm.json`);
   assertEquals(stat.isFile, true);
@@ -236,7 +236,6 @@ Deno.test("generateFsmJSONFromFolders - generates fsm.json for fsm folder", asyn
 Deno.test("generateFsmJSONFromFolders - generates fsm.json for vitalsWorkflow (shared)", async () => {
   await generateFsmJSONFromFolders(
     FSM_FOLDER,
-    "sharedFsm",
     SHARED_FSM_SKIP_DIRS,
   );
 
@@ -248,18 +247,17 @@ Deno.test("generateFsmJSONFromFolders - generates fsm.json for vitalsWorkflow (s
 
 Deno.test("generateFsmJSONFromFolders - showRecommendation=false produces no recommendation output", async () => {
   // Captures that the function completes without error when showRecommendation is false (default)
-  await generateFsmJSONFromFolders(FSM_FOLDER, "fsm", [], false);
+  await generateFsmJSONFromFolders(FSM_FOLDER, [], false);
 });
 
 Deno.test("generateFsmJSONFromFolders - showRecommendation=true runs AJV validation without throwing", async () => {
   // Should complete without throwing even if schema issues exist
-  await generateFsmJSONFromFolders(FSM_FOLDER, "fsm", [], true);
+  await generateFsmJSONFromFolders(FSM_FOLDER, [], true);
 });
 
 Deno.test("generateFsmJSONFromFolders - showRecommendation=true on vitalsWorkflow (shared) runs AJV validation without throwing", async () => {
   await generateFsmJSONFromFolders(
     FSM_FOLDER,
-    "sharedFsm",
     SHARED_FSM_SKIP_DIRS,
     true,
   );
@@ -267,13 +265,13 @@ Deno.test("generateFsmJSONFromFolders - showRecommendation=true on vitalsWorkflo
 
 Deno.test("generateFsmJSONFromFolders - respects skipDirs", async () => {
   // carVitals is skipped — its fsm.json may or may not exist but no error is thrown
-  await generateFsmJSONFromFolders(FSM_FOLDER, "fsm", ["carVitals"]);
+  await generateFsmJSONFromFolders(FSM_FOLDER, ["carVitals"]);
 });
 
 Deno.test("generateFsmJSONFromFolders - throws on path starting with '.'", async () => {
   let threw = false;
   try {
-    await generateFsmJSONFromFolders("./relative/path", "fsm");
+    await generateFsmJSONFromFolders("./relative/path");
   } catch (e) {
     threw = true;
     assertExists((e as Error).message.match(/cannot start with/i));
@@ -284,7 +282,7 @@ Deno.test("generateFsmJSONFromFolders - throws on path starting with '.'", async
 Deno.test("generateFsmJSONFromFolders - throws on path ending with '/'", async () => {
   let threw = false;
   try {
-    await generateFsmJSONFromFolders("some/path/", "fsm");
+    await generateFsmJSONFromFolders("some/path/");
   } catch (e) {
     threw = true;
     assertExists((e as Error).message.match(/cannot end with/i));


### PR DESCRIPTION
## Summary
- Removes the unused `workflowType`/`WorkflowType` parameter that was purely threaded through several compiler-ts helper functions and never read.
- Drops the now-dead `--workflow-type` CLI flag/README references for the affected commands.

Affected functions: `generateFsmJSONFromFolders`, `generateFsmJSONFromFolder`, `generateFsmJSONFromMachineFile`, `deleteFsmJSONFromFolders`, `deleteFsmJSONFromFolder`, `generateAsyncOperationLogicFromFolders`, `validateAsyncOperationFromFolders`, `generateSyncOperationLogicFromFolders`.

Closes #179

## Test plan
- [x] Existing unit tests updated to drop the removed parameter
- [x] `deno task test` in `packages/fsm-compiler-ts`: 76 passed, 2 pre-existing failures unrelated to this change (missing `apps/fsm-core-example` fixture — reproduces the same way on `main`)