### PR TITLE
chore(examples): fix creditCheck/v01 asyncOperationLanguage drift

### DIFF
--- a/apps/fsm-core-example/fsm/creditCheck/v01/fsm.json
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/fsm.json
@@ -385,12 +385,12 @@
                   "order": 8,
                   "invoke": [
                     {
+                      "asyncOperationLanguage": "rust",
                       "src": "checkBureauRust",
                       "id": "equiGavinFetchActor",
                       "type": "xstate.invoke",
                       "asyncOperationType": "internalAsyncOperation",
-                      "asyncOperationVersion": "v01",
-                      "asyncOperationLanguage": "rust"
+                      "asyncOperationVersion": "v01"
                     }
                   ],
                   "tags": []
@@ -527,12 +527,12 @@
                   "order": 11,
                   "invoke": [
                     {
+                      "asyncOperationLanguage": "go",
                       "src": "CheckReportsTable",
                       "id": "gavUnionDBActor",
                       "type": "xstate.invoke",
                       "asyncOperationType": "internalAsyncOperation",
-                      "asyncOperationVersion": "v01",
-                      "asyncOperationLanguage": "go"
+                      "asyncOperationVersion": "v01"
                     }
                   ],
                   "tags": []
@@ -630,12 +630,12 @@
                   "order": 13,
                   "invoke": [
                     {
+                      "asyncOperationLanguage": "python",
                       "src": "checkBureau",
                       "id": "gavUnionFetchActor",
                       "type": "xstate.invoke",
                       "asyncOperationType": "internalAsyncOperation",
-                      "asyncOperationVersion": "v01",
-                      "asyncOperationLanguage": "python"
+                      "asyncOperationVersion": "v01"
                     }
                   ],
                   "tags": []

--- a/apps/fsm-core-example/fsm/creditCheck/v01/machine.ts
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/machine.ts
@@ -91,6 +91,7 @@ export const machine = createMachine({
                       bureauName: "EquiGavin",
                       ssn: SSN,
                     }),
+                    asyncOperationLanguage: "rust",
                     src: "checkBureauRust",
                     id: "equiGavinFetchActor",
                     onDone: [
@@ -120,6 +121,7 @@ export const machine = createMachine({
                       bureauName: "GavUnion",
                       ssn: SSN,
                     }),
+                    asyncOperationLanguage: "go",
                     src: "CheckReportsTable",
                     id: "gavUnionDBActor",
                     onDone: [
@@ -149,6 +151,7 @@ export const machine = createMachine({
                       bureauName: "GavUnion",
                       ssn: SSN,
                     }),
+                    asyncOperationLanguage: "python",
                     src: "checkBureau",
                     id: "gavUnionFetchActor",
                     onDone: [

--- a/apps/fsm-core-example/fsm/creditCheck/v01/xstate-fsm.json
+++ b/apps/fsm-core-example/fsm/creditCheck/v01/xstate-fsm.json
@@ -379,6 +379,7 @@
                   "order": 8,
                   "invoke": [
                     {
+                      "asyncOperationLanguage": "rust",
                       "src": "checkBureauRust",
                       "id": "equiGavinFetchActor",
                       "type": "xstate.invoke"
@@ -518,6 +519,7 @@
                   "order": 11,
                   "invoke": [
                     {
+                      "asyncOperationLanguage": "go",
                       "src": "CheckReportsTable",
                       "id": "gavUnionDBActor",
                       "type": "xstate.invoke"
@@ -618,6 +620,7 @@
                   "order": 13,
                   "invoke": [
                     {
+                      "asyncOperationLanguage": "python",
                       "src": "checkBureau",
                       "id": "gavUnionFetchActor",
                       "type": "xstate.invoke"


### PR DESCRIPTION
## Summary
- `machine.ts` wasn't updated when `#190`/`#191` renamed invoke-object fields to `asyncOperationType`/`asyncOperationVersion`/`asyncOperationLanguage`, so the compiled `fsm.json`/`xstate-fsm.json` for `creditCheck/v01` were stale.
- Set `asyncOperationLanguage` on the three polyglot invoke configs (rust/go/python) and regenerated via `deno run --allow-all packages/fsm-compiler-ts/src/cli/index.ts -c generate -f apps/fsm-core-example/fsm`.

## Test plan
- [x] `deno fmt` passed via pre-commit hook
- [x] Regenerated `fsm.json`/`xstate-fsm.json` match compiler output with no unintended diffs

Closes #192