### PR TITLE
chore(database-src): full-ext migration filenames + schema_paths depth fix

### DIFF
--- a/packages/database-src/full-ext/supabase/config.toml
+++ b/packages/database-src/full-ext/supabase/config.toml
@@ -49,16 +49,16 @@ max_client_conn = 100
 # Specifies an ordered list of schema files that describe your database.
 # Supports glob patterns relative to supabase directory: "./../supabase/*.sql"
 schema_paths = [
-    "./../supabase/schemas/00_pre_ext/*.sql",
-    "./../supabase/05_ext_module_init/*.sql",
-    "./../supabase/10_ext_helper/*.sql",
-    "./../supabase/11_ext_base/*.sql",
-    "./../supabase/15_deprecated_fsm_core_macrostep_v1/*.sql",
-    "./../supabase/20_fsm_core_macrostep_v2/*.sql",
-    "./../supabase/25_async_operation_worker_v1/*.sql",
-    "./../supabase/30_async_operation_worker_v2/*.sql",
-    "./../supabase/35_fsm_sync_operation_worker_v1/*.sql",
-    "./../supabase/*.sql"
+    "./../../supabase/schemas/00_pre_ext/*.sql",
+    "./../../supabase/schemas/05_ext_module_init/*.sql",
+    "./../../supabase/schemas/10_ext_helper/*.sql",
+    "./../../supabase/schemas/11_ext_base/*.sql",
+    "./../../supabase/schemas/15_deprecated_fsm_core_macrostep_v1/*.sql",
+    "./../../supabase/schemas/20_fsm_core_macrostep_v2/*.sql",
+    "./../../supabase/schemas/25_async_operation_worker_v1/*.sql",
+    "./../../supabase/schemas/30_async_operation_worker_v2/*.sql",
+    "./../../supabase/schemas/35_fsm_sync_operation_worker_v1/*.sql",
+    "./../../supabase/schemas/*.sql"
 ]
 
 [db.seed]

--- a/packages/database-src/get-next-pkg-version-util.ts
+++ b/packages/database-src/get-next-pkg-version-util.ts
@@ -8,11 +8,20 @@ const DEFAULT_VERSION = "1.0.0";
  * next release: increments the highest version already recorded in
  * `migrationsDir` by `incrementType` (semver's `inc`), or starts at
  * `DEFAULT_VERSION` if no prior migration exists.
+ *
+ * `format` controls the naming convention:
+ * - "upgrade" (default): `{pkgName}--{old}--{new}.sql`, or just
+ *   `{pkgName}--{DEFAULT_VERSION}.sql` for the very first migration. This is
+ *   the PGXN upgrade-diff convention used by `supabase/migrations`.
+ * - "single": always `{pkgName}--{new}.sql`, no `old` segment — used for
+ *   `full-ext/supabase/migrations`, which holds one authoritative SQL file
+ *   per version rather than an upgrade chain.
  */
 export function getNextPkgVersionFilename(
   pkgName: string,
   incrementType: semver.ReleaseType,
   migrationsDir = "supabase/migrations",
+  format: "upgrade" | "single" = "upgrade",
 ): string {
   const existingHighest = getExistingHighestPkgVersion(pkgName, migrationsDir);
 
@@ -27,5 +36,7 @@ export function getNextPkgVersionFilename(
     );
   }
 
-  return `${pkgName}--${existingHighest}--${nextVersion}`;
+  return format === "single"
+    ? `${pkgName}--${nextVersion}`
+    : `${pkgName}--${existingHighest}--${nextVersion}`;
 }

--- a/packages/database-src/supabase-restart-with-diff.ts
+++ b/packages/database-src/supabase-restart-with-diff.ts
@@ -119,6 +119,7 @@ async function cleanDockerVolume(): Promise<void> {
 async function diffSchemaWithUpgradeScript(
   incrementType: ReleaseType,
   workdir: string,
+  target: Target,
 ): Promise<void> {
   const pkg = JSON.parse(
     await Deno.readTextFile(join(SCRIPT_DIR, "package.json")),
@@ -138,10 +139,15 @@ async function diffSchemaWithUpgradeScript(
   //   join(workdir, "supabase/migrations"),
   // );
 
+  // full-ext holds one authoritative SQL file per version (no upgrade-diff
+  // chain — see pgxn-build-and-publish.ts's full-ext override), so its
+  // filenames are always `{pkgName}--{version}.sql`, never
+  // `{pkgName}--{old}--{new}.sql`.
   const nextVersion = getNextPkgVersionFilename(
     pkg.name,
     incrementType,
     join(workdir, "supabase/migrations"),
+    target === "full-ext" ? "single" : "upgrade",
   );
   await run(SUPABASE_BIN, [
     "db",
@@ -186,7 +192,7 @@ async function restartWithDiffWithUpgradeScript(
   const workdir = WORKDIRS[target];
   await stopSupabase(workdir);
   await cleanDockerVolume();
-  await diffSchemaWithUpgradeScript(incrementType, workdir);
+  await diffSchemaWithUpgradeScript(incrementType, workdir, target);
   await startSupabaseWithEnv(workdir);
   await genTypes(workdir);
 }


### PR DESCRIPTION
## Summary

- `supabase-restart-with-diff.ts`'s `full-ext` target now names migration files `fsm_core--{version}.sql` (e.g. `fsm_core--1.1.0.sql` for version `1.1.0`) instead of the main project's `fsm_core--{old}--{new}.sql` upgrade-diff convention — full-ext holds one authoritative SQL file per version, not an upgrade chain (see the pgxn-build-and-publish.ts override logic from #197).
- `getNextPkgVersionFilename` gained a `format: "upgrade" | "single"` param (default `"upgrade"`, unchanged for the main project) to support this without duplicating the version-increment logic.
- Fixes `full-ext/supabase/config.toml`'s `schema_paths`, which still pointed one directory level too shallow (`./../supabase/schemas/...`) after the directory was nested under `full-ext/supabase/` in #197 — corrected to `./../../supabase/schemas/...`, also fixing a missing `schemas/` segment on most entries.

Closes #198

## Test plan

- [x] `deno check` on both `.ts` files — no errors
- [x] Verified filename computation directly: `full-ext` + `minor` bump from existing `1.0.0` → `fsm_core--1.1.0`; main project's `upgrade` format unaffected (`fsm_core--2.0.5--2.0.6`)
- [x] Reviewer: confirm `schema_paths` fix against a real `SUPABASE_WORKDIR=full-ext npm run supabase:start:env` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABTbktagtdWEe6KYjckV3N